### PR TITLE
fix(auth): flow hardening — scanner defense, frictionless, recovery, share URL (Phases 1-5 + Phase 6 logging)

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -224,17 +224,15 @@ async function refreshFromLobby(
   }
 }
 
-/** Return any locally-cached JWT to use as an identity hint for the lobby's
- *  /enter/CODE recovery endpoint. Prefers the most recently-issued (highest
- *  iat) so we hand the lobby the freshest proof-of-identity available.
- *  Returns null if nothing is stored — caller should route to /j/CODE. */
+/** Return the freshest locally-cached JWT to use as an identity hint for
+ *  the lobby's /enter/CODE recovery endpoint. localStorage and cookie
+ *  caches are unified into a single pool ranked by iat — a fresher token
+ *  in cookies beats a stale one in localStorage and vice versa. Returns
+ *  null if nothing is stored — caller should route to /j/CODE. */
 function findAnyJwtHint(): string | null {
   let best: { jwt: string; iat: number } | null = null;
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (!key?.startsWith('po_token_')) continue;
-    const jwt = localStorage.getItem(key);
-    if (!jwt) continue;
+  const consider = (jwt: string | null | undefined) => {
+    if (!jwt) return;
     try {
       const decoded = decodeGameToken(jwt);
       const iat = decoded.iat ?? 0;
@@ -242,20 +240,16 @@ function findAnyJwtHint(): string | null {
     } catch {
       // Malformed — skip.
     }
+  };
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key?.startsWith('po_token_')) continue;
+    consider(localStorage.getItem(key));
   }
-  if (best) return best.jwt;
-  // Fallback: scan po_pwa_* cookies
-  const matches = document.cookie.matchAll(/po_pwa_([^=]+)=([^;]+)/g);
-  for (const m of matches) {
-    try {
-      const jwt = m[2];
-      decodeGameToken(jwt); // parseable check
-      return jwt;
-    } catch {
-      // skip
-    }
+  for (const m of document.cookie.matchAll(/po_pwa_([^=]+)=([^;]+)/g)) {
+    consider(m[2]);
   }
-  return null;
+  return best ? (best as { jwt: string; iat: number }).jwt : null;
 }
 
 /** Ask the lobby which games the user is actively in.

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -592,6 +592,9 @@ export default function App() {
         }
       } catch (err) {
         console.error('[App] runAsyncRecovery: unexpected error for', code, ':', err);
+        // Tag this distinctly so "fell through from an error" hits don't
+        // look identical in Sentry to "reached step 4 as a normal fallback".
+        setSentryAuthMethod('lobby-recover-error');
         window.location.href = `${LOBBY_HOST}/j/${code}`;
       } finally {
         setRecovering(false);

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -224,19 +224,28 @@ async function refreshFromLobby(
   }
 }
 
+type JwtHintSource = 'localStorage' | 'cookie';
+
 /** Return the freshest locally-cached JWT to use as an identity hint for
  *  the lobby's /enter/CODE recovery endpoint. localStorage and cookie
  *  caches are unified into a single pool ranked by iat — a fresher token
  *  in cookies beats a stale one in localStorage and vice versa. Returns
- *  null if nothing is stored — caller should route to /j/CODE. */
-function findAnyJwtHint(): string | null {
-  let best: { jwt: string; iat: number } | null = null;
-  const consider = (jwt: string | null | undefined) => {
+ *  null if nothing is stored — caller should route to /j/CODE.
+ *
+ *  Also reports which source the winning JWT came from so callers can
+ *  tag distinct Sentry paths — helps spot "recovery succeeds only via
+ *  cookie fallback" patterns that point at a bigger localStorage-loss
+ *  issue. Safari private mode (or a sandboxed iframe) can throw on
+ *  localStorage access; the throw bubbles to runAsyncRecovery's outer
+ *  catch which redirects to /j/CODE — a clean degraded fallback. */
+function findAnyJwtHint(): { jwt: string; source: JwtHintSource } | null {
+  let best: { jwt: string; iat: number; source: JwtHintSource } | null = null;
+  const consider = (jwt: string | null | undefined, source: JwtHintSource) => {
     if (!jwt) return;
     try {
       const decoded = decodeGameToken(jwt);
       const iat = decoded.iat ?? 0;
-      if (!best || iat > best.iat) best = { jwt, iat };
+      if (!best || iat > best.iat) best = { jwt, iat, source };
     } catch {
       // Malformed — skip.
     }
@@ -244,12 +253,15 @@ function findAnyJwtHint(): string | null {
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i);
     if (!key?.startsWith('po_token_')) continue;
-    consider(localStorage.getItem(key));
+    consider(localStorage.getItem(key), 'localStorage');
   }
   for (const m of document.cookie.matchAll(/po_pwa_([^=]+)=([^;]+)/g)) {
-    consider(m[2]);
+    consider(m[2], 'cookie');
   }
-  return best ? (best as { jwt: string; iat: number }).jwt : null;
+  // Cast: the `consider` callback mutates `best` from inside a closure,
+  // which defeats TS control-flow narrowing after the truthy check.
+  const winner = best as { jwt: string; iat: number; source: JwtHintSource } | null;
+  return winner ? { jwt: winner.jwt, source: winner.source } : null;
 }
 
 /** Ask the lobby which games the user is actively in.
@@ -573,21 +585,30 @@ export default function App() {
         console.log(
           '[App] recovery step 4: redirecting to /enter/',
           code,
-          hint ? '(with JWT hint)' : '(no hint)',
+          hint ? `(with JWT hint from ${hint.source})` : '(no hint)',
         );
-        setSentryAuthMethod('lobby-recover');
+        // Tag the hint source so Sentry can distinguish localStorage
+        // recovery from cookie-fallback recovery. If data shows cookie
+        // dominates, that signals a localStorage-loss issue worth
+        // investigating separately.
         if (hint) {
+          setSentryAuthMethod(
+            hint.source === 'localStorage'
+              ? 'lobby-recover-localStorage'
+              : 'lobby-recover-cookie',
+          );
           const form = document.createElement('form');
           form.method = 'POST';
           form.action = `${LOBBY_HOST}/enter/${code}`;
           const input = document.createElement('input');
           input.type = 'hidden';
           input.name = 'hint';
-          input.value = hint;
+          input.value = hint.jwt;
           form.appendChild(input);
           document.body.appendChild(form);
           form.submit();
         } else {
+          setSentryAuthMethod('lobby-recover-none');
           window.location.href = `${LOBBY_HOST}/j/${code}`;
         }
       } catch (err) {

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -203,20 +203,57 @@ async function recoverFromCacheApi(gameCode: string): Promise<string | null> {
 }
 
 /** Try to mint a fresh JWT via the lobby's refresh-token API (requires po_session cookie). */
-async function refreshFromLobby(gameCode: string): Promise<string | null> {
+async function refreshFromLobby(
+  gameCode: string,
+): Promise<{ token: string | null; reason?: string }> {
   try {
     const res = await fetch(`${LOBBY_HOST}/api/refresh-token/${gameCode}`, {
       credentials: 'include', // sends po_session cookie
     });
     if (!res.ok) {
       console.warn('[App] refreshFromLobby: lobby returned', res.status, 'for', gameCode);
-      return null;
+      return { token: null, reason: `http_${res.status}` };
     }
-    const { token } = await res.json();
-    if (token) return token;
+    const { token, reason } = await res.json();
+    if (token) return { token, reason };
     console.warn('[App] refreshFromLobby: lobby returned 200 but no token for', gameCode);
+    return { token: null, reason: reason || 'no_token' };
   } catch (err) {
     console.warn('[App] Lobby token refresh failed:', err);
+    return { token: null, reason: 'network_error' };
+  }
+}
+
+/** Return any locally-cached JWT to use as an identity hint for the lobby's
+ *  /enter/CODE recovery endpoint. Prefers the most recently-issued (highest
+ *  iat) so we hand the lobby the freshest proof-of-identity available.
+ *  Returns null if nothing is stored — caller should route to /j/CODE. */
+function findAnyJwtHint(): string | null {
+  let best: { jwt: string; iat: number } | null = null;
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key?.startsWith('po_token_')) continue;
+    const jwt = localStorage.getItem(key);
+    if (!jwt) continue;
+    try {
+      const decoded = decodeGameToken(jwt);
+      const iat = decoded.iat ?? 0;
+      if (!best || iat > best.iat) best = { jwt, iat };
+    } catch {
+      // Malformed — skip.
+    }
+  }
+  if (best) return best.jwt;
+  // Fallback: scan po_pwa_* cookies
+  const matches = document.cookie.matchAll(/po_pwa_([^=]+)=([^;]+)/g);
+  for (const m of matches) {
+    try {
+      const jwt = m[2];
+      decodeGameToken(jwt); // parseable check
+      return jwt;
+    } catch {
+      // skip
+    }
   }
   return null;
 }
@@ -524,22 +561,44 @@ export default function App() {
         console.log('[App] recovery step 2: no Cache API token for', code);
 
         // Step 3: Lobby API (mint fresh JWT via po_session cookie)
-        const fromLobby = await refreshFromLobby(code);
+        const { token: fromLobby, reason: refreshReason } = await refreshFromLobby(code);
         if (fromLobby) {
           console.log('[App] recovery step 3: refreshed from lobby for', code);
           applyToken(fromLobby, code, setGameId, setPlayerId, setToken);
           setSentryAuthMethod('lobby-refresh');
           return;
         }
-        console.log('[App] recovery step 3: lobby refresh failed for', code);
+        console.log('[App] recovery step 3: lobby refresh failed for', code, refreshReason);
 
-        // Step 4: Redirect to lobby (last resort — user may need to log in)
-        console.log('[App] recovery step 4: redirecting to lobby for', code);
-        setSentryAuthMethod('lobby-redirect');
-        window.location.href = `${LOBBY_HOST}/play/${code}`;
+        // Step 4: Hand off to lobby's /enter/CODE with any JWT we can find
+        // as an identity hint — lobby restores session from sub if the
+        // signature is valid (even if expired). POSTed via form to keep
+        // the JWT out of URL params, browser history, and access logs.
+        // No hint → straight to /j/CODE welcome.
+        const hint = findAnyJwtHint();
+        console.log(
+          '[App] recovery step 4: redirecting to /enter/',
+          code,
+          hint ? '(with JWT hint)' : '(no hint)',
+        );
+        setSentryAuthMethod('lobby-recover');
+        if (hint) {
+          const form = document.createElement('form');
+          form.method = 'POST';
+          form.action = `${LOBBY_HOST}/enter/${code}`;
+          const input = document.createElement('input');
+          input.type = 'hidden';
+          input.name = 'hint';
+          input.value = hint;
+          form.appendChild(input);
+          document.body.appendChild(form);
+          form.submit();
+        } else {
+          window.location.href = `${LOBBY_HOST}/j/${code}`;
+        }
       } catch (err) {
         console.error('[App] runAsyncRecovery: unexpected error for', code, ':', err);
-        window.location.href = `${LOBBY_HOST}/play/${code}`;
+        window.location.href = `${LOBBY_HOST}/j/${code}`;
       } finally {
         setRecovering(false);
       }
@@ -738,6 +797,18 @@ function LauncherScreen({ lobbyGames, archivedGameCode }: {
           </button>
         </div>
       </form>
+
+      {cachedGames.length === 0 && (
+        <div className="w-full max-w-sm text-center space-y-2">
+          <p className="text-xs text-skin-dim/60 font-body">Played before?</p>
+          <a
+            href={`${LOBBY_HOST}/login`}
+            className="inline-block px-4 py-2 rounded-lg border border-skin-gold/30 bg-glass text-xs font-mono font-bold text-skin-gold uppercase tracking-widest hover:border-skin-gold/60 transition-all"
+          >
+            Sign in with email
+          </a>
+        </div>
+      )}
 
       {/* Lobby link */}
       <a

--- a/apps/client/src/lib/sentry.ts
+++ b/apps/client/src/lib/sentry.ts
@@ -60,7 +60,7 @@ export function setSentryPwaContext(data: {
 }
 
 /** Set a tag for how the player's token was resolved. */
-export function setSentryAuthMethod(method: 'transient' | 'cached' | 'cookie' | 'cache-api' | 'lobby-refresh' | 'lobby-redirect' | 'lobby-recover' | 'raw-token' | 'debug') {
+export function setSentryAuthMethod(method: 'transient' | 'cached' | 'cookie' | 'cache-api' | 'lobby-refresh' | 'lobby-recover' | 'lobby-recover-error' | 'raw-token' | 'debug') {
   Sentry.setTag('authMethod', method);
 }
 

--- a/apps/client/src/lib/sentry.ts
+++ b/apps/client/src/lib/sentry.ts
@@ -60,7 +60,20 @@ export function setSentryPwaContext(data: {
 }
 
 /** Set a tag for how the player's token was resolved. */
-export function setSentryAuthMethod(method: 'transient' | 'cached' | 'cookie' | 'cache-api' | 'lobby-refresh' | 'lobby-recover' | 'lobby-recover-error' | 'raw-token' | 'debug') {
+export function setSentryAuthMethod(
+  method:
+    | 'transient'
+    | 'cached'
+    | 'cookie'
+    | 'cache-api'
+    | 'lobby-refresh'
+    | 'lobby-recover-localStorage'
+    | 'lobby-recover-cookie'
+    | 'lobby-recover-none'
+    | 'lobby-recover-error'
+    | 'raw-token'
+    | 'debug',
+) {
   Sentry.setTag('authMethod', method);
 }
 

--- a/apps/client/src/lib/sentry.ts
+++ b/apps/client/src/lib/sentry.ts
@@ -60,7 +60,7 @@ export function setSentryPwaContext(data: {
 }
 
 /** Set a tag for how the player's token was resolved. */
-export function setSentryAuthMethod(method: 'transient' | 'cached' | 'cookie' | 'cache-api' | 'lobby-refresh' | 'lobby-redirect' | 'raw-token' | 'debug') {
+export function setSentryAuthMethod(method: 'transient' | 'cached' | 'cookie' | 'cache-api' | 'lobby-refresh' | 'lobby-redirect' | 'lobby-recover' | 'raw-token' | 'debug') {
   Sentry.setTag('authMethod', method);
 }
 

--- a/apps/lobby/__tests__/enter-route.test.ts
+++ b/apps/lobby/__tests__/enter-route.test.ts
@@ -120,6 +120,21 @@ describe('/enter/[code]', () => {
       expect(res.status).toBe(307);
       expect(res.headers.get('location')).toContain(`/play/${CODE}`);
     });
+
+    it('nonexistent game (no session) → 307 /login?error=Game+not+found', async () => {
+      mockDb = createMockDb(null);
+      const res = await GET(getReq(CODE), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('Game+not+found');
+    });
+
+    it('nonexistent game (session present) → also /login?error=Game+not+found (symmetry)', async () => {
+      mockDb = createMockDb(null);
+      sessionReturn = { userId: USER_ID };
+      const res = await GET(getReq(CODE), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('Game+not+found');
+    });
   });
 
   describe('POST', () => {

--- a/apps/lobby/__tests__/enter-route.test.ts
+++ b/apps/lobby/__tests__/enter-route.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { SignJWT } from 'jose';
+import { signGameToken } from '@pecking-order/auth';
+
+const AUTH_SECRET = 'test-secret-for-enter-route';
+const OTHER_SECRET = 'different-secret-for-bad-signature';
+
+type GameRow = { id: string; status: string };
+type UserRow = { id: string };
+
+function createMockDb(game: GameRow | null, users: UserRow[] = []) {
+  const sessions: Array<{ id: string; user_id: string }> = [];
+  return {
+    sessions,
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            first: async () => {
+              if (sql.startsWith('SELECT id, status FROM GameSessions')) {
+                return game;
+              }
+              if (sql.startsWith('SELECT id FROM Users WHERE id = ?')) {
+                const match = users.find((u) => u.id === args[0]);
+                return match ?? null;
+              }
+              return null;
+            },
+            run: async () => {
+              if (sql.startsWith('INSERT INTO Sessions')) {
+                const [id, user_id] = args as [string, string];
+                sessions.push({ id, user_id });
+                return { success: true, meta: { changes: 1 } };
+              }
+              return { success: true, meta: { changes: 1 } };
+            },
+            all: async () => ({ results: [] }),
+          };
+        },
+      };
+    },
+    batch: async () => [],
+  };
+}
+
+let mockDb: ReturnType<typeof createMockDb>;
+let sessionReturn: { userId: string } | null = null;
+
+vi.mock('@/lib/db', () => ({
+  getEnv: vi.fn(async () => ({ AUTH_SECRET })),
+  getDB: vi.fn(async () => mockDb),
+}));
+
+vi.mock('@/lib/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('../lib/auth')>('@/lib/auth');
+  return {
+    ...actual,
+    getSession: vi.fn(async () => sessionReturn),
+    setSessionCookie: vi.fn(async () => {}),
+    generateToken: () => 'fixed-session-id',
+  };
+});
+
+vi.mock('next/headers', () => ({
+  cookies: async () => ({ get: () => undefined, set: vi.fn(), delete: vi.fn() }),
+}));
+
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
+
+// Import AFTER mocks so the route resolves against them.
+import { GET, POST } from '@/app/enter/[code]/route';
+
+const CODE = 'TESTCD';
+const GAME_ID = 'game-test-1';
+const USER_ID = 'user-1';
+
+async function signExpiredFor(sub: string, secret: string) {
+  const key = new TextEncoder().encode(secret);
+  return new SignJWT({
+    sub,
+    gameId: GAME_ID,
+    playerId: 'p1',
+    personaName: 'Test',
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
+    .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+    .sign(key);
+}
+
+function postReq(code: string, form: FormData) {
+  return new NextRequest(`http://localhost/enter/${code}`, {
+    method: 'POST',
+    body: form,
+  });
+}
+
+function getReq(code: string) {
+  return new NextRequest(`http://localhost/enter/${code}`, { method: 'GET' });
+}
+
+describe('/enter/[code]', () => {
+  beforeEach(() => {
+    mockDb = createMockDb({ id: GAME_ID, status: 'STARTED' }, [{ id: USER_ID }]);
+    sessionReturn = null;
+  });
+
+  describe('GET', () => {
+    it('no session → 307 /j/CODE', async () => {
+      const res = await GET(getReq(CODE), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain(`/j/${CODE}`);
+    });
+
+    it('session present → 307 /play/CODE', async () => {
+      sessionReturn = { userId: USER_ID };
+      const res = await GET(getReq(CODE), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain(`/play/${CODE}`);
+    });
+  });
+
+  describe('POST', () => {
+    it('existing session short-circuits regardless of hint', async () => {
+      sessionReturn = { userId: USER_ID };
+      const form = new FormData();
+      form.set('hint', 'would-not-be-used');
+      const res = await POST(postReq(CODE, form), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/play/${CODE}`);
+      // No session should be minted — short-circuit happens BEFORE hint processing.
+      expect(mockDb.sessions).toHaveLength(0);
+    });
+
+    it('nonexistent game → 303 /login?error=Game+not+found', async () => {
+      mockDb = createMockDb(null);
+      const form = new FormData();
+      const res = await POST(postReq(CODE, form), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain('Game+not+found');
+    });
+
+    it('no hint + valid game → 303 /j/CODE (fall-through)', async () => {
+      const form = new FormData();
+      const res = await POST(postReq(CODE, form), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/j/${CODE}`);
+      expect(mockDb.sessions).toHaveLength(0);
+    });
+
+    it('empty hint + valid game → 303 /j/CODE', async () => {
+      const form = new FormData();
+      form.set('hint', '');
+      const res = await POST(postReq(CODE, form), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/j/${CODE}`);
+      expect(mockDb.sessions).toHaveLength(0);
+    });
+
+    it('malformed hint → 303 /j/CODE (verify throws, caught)', async () => {
+      const form = new FormData();
+      form.set('hint', 'not.a.real.jwt');
+      const res = await POST(postReq(CODE, form), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/j/${CODE}`);
+      expect(mockDb.sessions).toHaveLength(0);
+    });
+
+    it('bad-signature hint → 303 /j/CODE (rejected, no session)', async () => {
+      const badHint = await signGameToken(
+        { sub: USER_ID, gameId: GAME_ID, playerId: 'p1', personaName: 'X' },
+        OTHER_SECRET,
+        '5m',
+      );
+      const form = new FormData();
+      form.set('hint', badHint);
+      const res = await POST(postReq(CODE, form), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/j/${CODE}`);
+      expect(mockDb.sessions).toHaveLength(0);
+    });
+
+    it('expired-but-signature-valid hint for existing user → 303 /play/CODE + session created', async () => {
+      const hint = await signExpiredFor(USER_ID, AUTH_SECRET);
+      const form = new FormData();
+      form.set('hint', hint);
+      const res = await POST(postReq(CODE, form), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/play/${CODE}`);
+      expect(mockDb.sessions).toHaveLength(1);
+      expect(mockDb.sessions[0].user_id).toBe(USER_ID);
+    });
+
+    it('expired-but-signature-valid hint for MISSING user → 303 /j/CODE (no session)', async () => {
+      mockDb = createMockDb({ id: GAME_ID, status: 'STARTED' }, []); // no users
+      const hint = await signExpiredFor('ghost-user', AUTH_SECRET);
+      const form = new FormData();
+      form.set('hint', hint);
+      const res = await POST(postReq(CODE, form), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/j/${CODE}`);
+      expect(mockDb.sessions).toHaveLength(0);
+    });
+
+    it('valid-unexpired hint for existing user → 303 /play/CODE + session created', async () => {
+      const hint = await signGameToken(
+        { sub: USER_ID, gameId: GAME_ID, playerId: 'p1', personaName: 'X' },
+        AUTH_SECRET,
+        '5m',
+      );
+      const form = new FormData();
+      form.set('hint', hint);
+      const res = await POST(postReq(CODE, form), { params: Promise.resolve({ code: CODE }) });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/play/${CODE}`);
+      expect(mockDb.sessions).toHaveLength(1);
+    });
+  });
+});

--- a/apps/lobby/__tests__/invite-route.test.ts
+++ b/apps/lobby/__tests__/invite-route.test.ts
@@ -228,7 +228,7 @@ describe('/invite/[token]', () => {
       expect(setCookie).toContain('po_session=');
     });
 
-    it('POST twice in rapid succession → second hits already-used branch (single session)', async () => {
+    it('POST twice serially (idempotency, not concurrency) → second hits already-used branch', async () => {
       mockDb = createMockDb(freshInvite());
       const form1 = new FormData();
       await POST(req('POST', VALID_TOKEN, form1), {

--- a/apps/lobby/__tests__/invite-route.test.ts
+++ b/apps/lobby/__tests__/invite-route.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Minimal D1 mock. Represents a single InviteTokens row and the side-effect
+// log of writes so tests can assert "token not consumed" vs "token consumed".
+type InviteRow = {
+  token: string;
+  email: string;
+  game_id: string;
+  invite_code: string;
+  expires_at: number;
+  used: number;
+};
+
+function createMockDb(invite: InviteRow | null) {
+  const log: Array<{ sql: string; args: unknown[] }> = [];
+  const users = new Map<string, { id: string }>();
+  const sessions: Array<{ id: string; user_id: string }> = [];
+  let inviteState = invite ? { ...invite } : null;
+
+  const db = {
+    log,
+    get invite() {
+      return inviteState;
+    },
+    sessions,
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          log.push({ sql, args });
+          return {
+            first: async () => {
+              if (sql.startsWith('SELECT token, email, game_id, invite_code, expires_at, used')) {
+                return inviteState && inviteState.token === args[0] ? inviteState : null;
+              }
+              if (sql.startsWith('SELECT id FROM Users WHERE email = ?')) {
+                return users.get(args[0] as string) ?? null;
+              }
+              return null;
+            },
+            run: async () => {
+              if (sql.startsWith('UPDATE InviteTokens SET used = 1')) {
+                if (inviteState && inviteState.token === args[0]) {
+                  inviteState = { ...inviteState, used: 1 };
+                }
+                return { success: true };
+              }
+              if (sql.startsWith('INSERT INTO Users')) {
+                const [id, email] = args as [string, string];
+                users.set(email, { id });
+                return { success: true };
+              }
+              if (sql.startsWith('UPDATE Users SET last_login_at')) {
+                return { success: true };
+              }
+              if (sql.startsWith('INSERT INTO Sessions')) {
+                const [id, user_id] = args as [string, string];
+                sessions.push({ id, user_id });
+                return { success: true };
+              }
+              return { success: true };
+            },
+          };
+        },
+      };
+    },
+  };
+  return db;
+}
+
+let mockInvite: InviteRow | null = null;
+let mockDb: ReturnType<typeof createMockDb>;
+
+vi.mock('@/lib/db', () => ({
+  getEnv: vi.fn(async () => ({})),
+  getDB: vi.fn(async () => mockDb),
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: async () => ({ get: () => undefined, set: vi.fn(), delete: vi.fn() }),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+}));
+
+// Import AFTER mocks so the route's getDB resolves to ours.
+import { GET, POST } from '@/app/invite/[token]/route';
+
+const VALID_TOKEN = 'a'.repeat(64);
+const INVITE_CODE = 'ABC123';
+const GAME_ID = 'game-1';
+
+function freshInvite(overrides?: Partial<InviteRow>): InviteRow {
+  return {
+    token: VALID_TOKEN,
+    email: 'test@example.com',
+    game_id: GAME_ID,
+    invite_code: INVITE_CODE,
+    expires_at: Date.now() + 24 * 60 * 60 * 1000,
+    used: 0,
+    ...overrides,
+  };
+}
+
+function req(method: 'GET' | 'POST', token: string, body?: FormData) {
+  const url = `http://localhost/invite/${token}`;
+  return new NextRequest(url, { method, body });
+}
+
+describe('/invite/[token]', () => {
+  beforeEach(() => {
+    mockInvite = null;
+    mockDb = createMockDb(null);
+  });
+
+  describe('GET', () => {
+    it('unknown token → redirect to /login with invalid error', async () => {
+      mockDb = createMockDb(null);
+      const res = await GET(req('GET', 'nope'), { params: Promise.resolve({ token: 'nope' }) });
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('/login?error=Invalid+invite+link');
+    });
+
+    it('expired token → redirect to /login with expired error', async () => {
+      mockDb = createMockDb(freshInvite({ expires_at: Date.now() - 60_000 }));
+      const res = await GET(req('GET', VALID_TOKEN), {
+        params: Promise.resolve({ token: VALID_TOKEN }),
+      });
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('/login?error=Invite+link+expired');
+      // Token must not be consumed on GET for any branch.
+      expect(mockDb.invite?.used).toBe(0);
+    });
+
+    it('already-used token → redirect to /j/CODE', async () => {
+      mockDb = createMockDb(freshInvite({ used: 1 }));
+      const res = await GET(req('GET', VALID_TOKEN), {
+        params: Promise.resolve({ token: VALID_TOKEN }),
+      });
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain(`/j/${INVITE_CODE}`);
+    });
+
+    it('valid-unused token → 200 HTML, token STILL unused', async () => {
+      mockDb = createMockDb(freshInvite());
+      const res = await GET(req('GET', VALID_TOKEN), {
+        params: Promise.resolve({ token: VALID_TOKEN }),
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toContain('text/html');
+      const body = await res.text();
+      expect(body).toContain(`/invite/${VALID_TOKEN}`);
+      expect(body).toContain(`Continue to game ${INVITE_CODE}`);
+      // The critical assertion — GET must never consume the token.
+      expect(mockDb.invite?.used).toBe(0);
+      const updates = mockDb.log.filter((l) => l.sql.startsWith('UPDATE InviteTokens'));
+      expect(updates).toHaveLength(0);
+    });
+  });
+
+  describe('POST', () => {
+    it('unknown token → 303 to /login with invalid error', async () => {
+      mockDb = createMockDb(null);
+      const form = new FormData();
+      const res = await POST(req('POST', 'nope', form), {
+        params: Promise.resolve({ token: 'nope' }),
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain('/login?error=Invalid+invite+link');
+    });
+
+    it('expired token → 303 to /login with expired error, token not consumed', async () => {
+      mockDb = createMockDb(freshInvite({ expires_at: Date.now() - 60_000 }));
+      const form = new FormData();
+      const res = await POST(req('POST', VALID_TOKEN, form), {
+        params: Promise.resolve({ token: VALID_TOKEN }),
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain('/login?error=Invite+link+expired');
+      expect(mockDb.invite?.used).toBe(0);
+    });
+
+    it('already-used token → 303 to /j/CODE, idempotent (no session created)', async () => {
+      mockDb = createMockDb(freshInvite({ used: 1 }));
+      const form = new FormData();
+      const res = await POST(req('POST', VALID_TOKEN, form), {
+        params: Promise.resolve({ token: VALID_TOKEN }),
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/j/${INVITE_CODE}`);
+      expect(mockDb.sessions).toHaveLength(0);
+    });
+
+    it('valid-unused token → 303 to /join/CODE, token consumed, session created, cookie set', async () => {
+      mockDb = createMockDb(freshInvite());
+      const form = new FormData();
+      const res = await POST(req('POST', VALID_TOKEN, form), {
+        params: Promise.resolve({ token: VALID_TOKEN }),
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/join/${INVITE_CODE}`);
+      expect(mockDb.invite?.used).toBe(1);
+      expect(mockDb.sessions).toHaveLength(1);
+      const setCookie = res.headers.get('set-cookie');
+      expect(setCookie).toBeTruthy();
+      expect(setCookie).toContain('po_session=');
+    });
+
+    it('POST twice in rapid succession → second hits already-used branch (single session)', async () => {
+      mockDb = createMockDb(freshInvite());
+      const form1 = new FormData();
+      await POST(req('POST', VALID_TOKEN, form1), {
+        params: Promise.resolve({ token: VALID_TOKEN }),
+      });
+      const form2 = new FormData();
+      const res2 = await POST(req('POST', VALID_TOKEN, form2), {
+        params: Promise.resolve({ token: VALID_TOKEN }),
+      });
+      expect(res2.status).toBe(303);
+      expect(res2.headers.get('location')).toContain(`/j/${INVITE_CODE}`);
+      expect(mockDb.sessions).toHaveLength(1);
+    });
+  });
+});

--- a/apps/lobby/__tests__/invite-route.test.ts
+++ b/apps/lobby/__tests__/invite-route.test.ts
@@ -17,6 +17,9 @@ function createMockDb(invite: InviteRow | null) {
   const users = new Map<string, { id: string }>();
   const sessions: Array<{ id: string; user_id: string }> = [];
   let inviteState = invite ? { ...invite } : null;
+  // Simulates a concurrent consumer that flips used 0→1 between the
+  // route's SELECT and its UPDATE. Set to true before calling POST.
+  let simulateRace = false;
 
   const db = {
     log,
@@ -24,6 +27,9 @@ function createMockDb(invite: InviteRow | null) {
       return inviteState;
     },
     sessions,
+    triggerRace: () => {
+      simulateRace = true;
+    },
     prepare(sql: string) {
       return {
         bind(...args: unknown[]) {
@@ -39,26 +45,41 @@ function createMockDb(invite: InviteRow | null) {
               return null;
             },
             run: async () => {
-              if (sql.startsWith('UPDATE InviteTokens SET used = 1')) {
+              if (sql.startsWith('UPDATE InviteTokens SET used = 1 WHERE token = ? AND used = 0')) {
+                // Race-safe consume: only "changes" when the row was still unused.
+                // If simulateRace was triggered, a concurrent consumer flipped
+                // used to 1 between the route's SELECT and this UPDATE.
+                if (simulateRace && inviteState) {
+                  inviteState = { ...inviteState, used: 1 };
+                  return { success: true, meta: { changes: 0 } };
+                }
+                if (inviteState && inviteState.token === args[0] && inviteState.used === 0) {
+                  inviteState = { ...inviteState, used: 1 };
+                  return { success: true, meta: { changes: 1 } };
+                }
+                return { success: true, meta: { changes: 0 } };
+              }
+              if (sql.startsWith('UPDATE InviteTokens SET used = 1 WHERE token = ?')) {
+                // Legacy unguarded consume kept for older callers.
                 if (inviteState && inviteState.token === args[0]) {
                   inviteState = { ...inviteState, used: 1 };
                 }
-                return { success: true };
+                return { success: true, meta: { changes: 1 } };
               }
               if (sql.startsWith('INSERT INTO Users')) {
                 const [id, email] = args as [string, string];
                 users.set(email, { id });
-                return { success: true };
+                return { success: true, meta: { changes: 1 } };
               }
               if (sql.startsWith('UPDATE Users SET last_login_at')) {
-                return { success: true };
+                return { success: true, meta: { changes: 1 } };
               }
               if (sql.startsWith('INSERT INTO Sessions')) {
                 const [id, user_id] = args as [string, string];
                 sessions.push({ id, user_id });
-                return { success: true };
+                return { success: true, meta: { changes: 1 } };
               }
-              return { success: true };
+              return { success: true, meta: { changes: 0 } };
             },
           };
         },
@@ -220,6 +241,23 @@ describe('/invite/[token]', () => {
       expect(res2.status).toBe(303);
       expect(res2.headers.get('location')).toContain(`/j/${INVITE_CODE}`);
       expect(mockDb.sessions).toHaveLength(1);
+    });
+
+    it('D1-level race (concurrent consumer wins) → UPDATE changes=0, no session created', async () => {
+      // Simulates two concurrent POSTs both reading used=0 under the
+      // route's loadInvite(). The guarded UPDATE ... AND used = 0 ensures
+      // only one wins at the DB level. The loser gets meta.changes === 0
+      // and must bail to the already-used branch.
+      mockDb = createMockDb(freshInvite());
+      mockDb.triggerRace();
+      const form = new FormData();
+      const res = await POST(req('POST', VALID_TOKEN, form), {
+        params: Promise.resolve({ token: VALID_TOKEN }),
+      });
+      expect(res.status).toBe(303);
+      expect(res.headers.get('location')).toContain(`/j/${INVITE_CODE}`);
+      expect(mockDb.sessions).toHaveLength(0);
+      expect(res.headers.get('set-cookie')).toBeFalsy();
     });
   });
 });

--- a/apps/lobby/__tests__/verifyGameToken.test.ts
+++ b/apps/lobby/__tests__/verifyGameToken.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { SignJWT, errors as joseErrors } from 'jose';
+import { signGameToken, verifyGameToken } from '@pecking-order/auth';
+
+const SECRET = 'test-secret-for-verifyGameToken-tests';
+const OTHER_SECRET = 'different-secret-for-signature-tests';
+
+async function signExpired(secret: string) {
+  // Produce a signed token whose exp is already in the past.
+  const key = new TextEncoder().encode(secret);
+  return new SignJWT({
+    sub: 'user-1',
+    gameId: 'game-1',
+    playerId: 'p1',
+    personaName: 'Test',
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
+    .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+    .sign(key);
+}
+
+describe('verifyGameToken', () => {
+  it('returns payload for a valid unexpired token', async () => {
+    const token = await signGameToken(
+      { sub: 'u', gameId: 'g', playerId: 'p1', personaName: 'X' },
+      SECRET,
+      '5m',
+    );
+    const payload = await verifyGameToken(token, SECRET);
+    expect(payload.sub).toBe('u');
+    expect(payload.gameId).toBe('g');
+  });
+
+  it('throws JWTExpired on expired token when ignoreExpiration is omitted', async () => {
+    const token = await signExpired(SECRET);
+    await expect(verifyGameToken(token, SECRET)).rejects.toBeInstanceOf(
+      joseErrors.JWTExpired,
+    );
+  });
+
+  it('returns payload for expired token when ignoreExpiration: true', async () => {
+    const token = await signExpired(SECRET);
+    const payload = await verifyGameToken(token, SECRET, { ignoreExpiration: true });
+    expect(payload.sub).toBe('user-1');
+    expect(payload.playerId).toBe('p1');
+  });
+
+  it('throws on bad signature regardless of ignoreExpiration', async () => {
+    const token = await signGameToken(
+      { sub: 'u', gameId: 'g', playerId: 'p1', personaName: 'X' },
+      OTHER_SECRET,
+      '5m',
+    );
+    await expect(verifyGameToken(token, SECRET)).rejects.toThrow();
+    await expect(
+      verifyGameToken(token, SECRET, { ignoreExpiration: true }),
+    ).rejects.toThrow();
+  });
+
+  it('throws on malformed token regardless of ignoreExpiration', async () => {
+    await expect(verifyGameToken('not.a.jwt', SECRET)).rejects.toThrow();
+    await expect(
+      verifyGameToken('not.a.jwt', SECRET, { ignoreExpiration: true }),
+    ).rejects.toThrow();
+  });
+
+  it('throws on expired+bad-signature even with ignoreExpiration (signature check first)', async () => {
+    const token = await signExpired(OTHER_SECRET);
+    await expect(
+      verifyGameToken(token, SECRET, { ignoreExpiration: true }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/lobby/__tests__/verifyGameToken.test.ts
+++ b/apps/lobby/__tests__/verifyGameToken.test.ts
@@ -32,6 +32,19 @@ describe('verifyGameToken', () => {
     expect(payload.gameId).toBe('g');
   });
 
+  it('returns payload for a valid unexpired token with ignoreExpiration: true', async () => {
+    // Happy path when a caller defensively passes the flag even though
+    // the token is still live. Should NOT enter the JWTExpired catch.
+    const token = await signGameToken(
+      { sub: 'u', gameId: 'g', playerId: 'p1', personaName: 'X' },
+      SECRET,
+      '5m',
+    );
+    const payload = await verifyGameToken(token, SECRET, { ignoreExpiration: true });
+    expect(payload.sub).toBe('u');
+    expect(payload.gameId).toBe('g');
+  });
+
   it('throws JWTExpired on expired token when ignoreExpiration is omitted', async () => {
     const token = await signExpired(SECRET);
     await expect(verifyGameToken(token, SECRET)).rejects.toBeInstanceOf(

--- a/apps/lobby/app/actions.ts
+++ b/apps/lobby/app/actions.ts
@@ -725,8 +725,6 @@ export async function startGame(
 
   // Build roster
   const roster: Roster = {};
-  const tokens: Record<string, string> = {};
-
   for (let i = 0; i < invites.length; i++) {
     const inv = invites[i];
     const pid = `p${i + 1}`;
@@ -743,18 +741,27 @@ export async function startGame(
       gold: 0,
       destinyId: 'FLOAT',
     };
+  }
 
-    // Mint JWT for each player (expiry = 2× game length + 7 day buffer)
+  // Mint JWT ONLY for the calling user, not all players. Handing every
+  // player's token back to the starter opened the host-impersonation
+  // pitfall where the waiting room's `Object.keys(tokens)[0]` drove any
+  // slot other than p1 into the client as p1. Mirror getGameSessionStatus.
+  const myInviteIndex = invites.findIndex((i) => i.accepted_by === session.userId);
+  const tokens: Record<string, string> = {};
+  if (myInviteIndex >= 0) {
+    const myPid = `p${myInviteIndex + 1}`;
+    const myInvite = invites[myInviteIndex];
     const tokenExpiry = `${game.day_count * 2 + 7}d`;
-    tokens[pid] = await signGameToken(
+    tokens[myPid] = await signGameToken(
       {
-        sub: inv.accepted_by,
+        sub: session.userId,
         gameId: game.id,
-        playerId: pid,
-        personaName: inv.persona_name,
+        playerId: myPid,
+        personaName: myInvite.persona_name,
       },
       AUTH_SECRET,
-      tokenExpiry
+      tokenExpiry,
     );
   }
 

--- a/apps/lobby/app/actions.ts
+++ b/apps/lobby/app/actions.ts
@@ -748,12 +748,26 @@ export async function startGame(
   // pitfall where the waiting room's `Object.keys(tokens)[0]` drove any
   // slot other than p1 into the client as p1. Mirror getGameSessionStatus.
   const myInviteIndex = invites.findIndex((i) => i.accepted_by === session.userId);
-  const tokens: Record<string, string> = {};
-  if (myInviteIndex >= 0) {
-    const myPid = `p${myInviteIndex + 1}`;
-    const myInvite = invites[myInviteIndex];
-    const tokenExpiry = `${game.day_count * 2 + 7}d`;
-    tokens[myPid] = await signGameToken(
+  if (myInviteIndex < 0) {
+    // Guaranteed impossible by the isParticipant check above — both queries
+    // look at `Invites WHERE game_id = ? AND accepted_by = session.userId`.
+    // The only way to reach here is a concurrent DELETE between them. Fail
+    // loudly so the waiting room doesn't silently ship tokens: {} into a
+    // client that would then render Object.keys(tokens)[0] === undefined.
+    console.error(
+      '[startGame] race: isParticipant passed but invite missing from roster',
+      { gameId: game.id, userId: session.userId },
+    );
+    return {
+      success: false,
+      error: 'Could not reserve a seat — please refresh and try again.',
+    };
+  }
+  const myPid = `p${myInviteIndex + 1}`;
+  const myInvite = invites[myInviteIndex];
+  const tokenExpiry = `${game.day_count * 2 + 7}d`;
+  const tokens: Record<string, string> = {
+    [myPid]: await signGameToken(
       {
         sub: session.userId,
         gameId: game.id,
@@ -762,8 +776,8 @@ export async function startGame(
       },
       AUTH_SECRET,
       tokenExpiry,
-    );
-  }
+    ),
+  };
 
   const now = Date.now();
 

--- a/apps/lobby/app/components/DynamicRulesetBuilder.tsx
+++ b/apps/lobby/app/components/DynamicRulesetBuilder.tsx
@@ -746,14 +746,14 @@ export function DynamicRulesetBuilder({
               type="button"
               data-testid="start-time-now-btn"
               onClick={() => {
-                const soon = new Date(Date.now() + 2 * 60_000);
+                const soon = new Date(Date.now() + 5 * 60_000);
                 const local = new Date(soon.getTime() - soon.getTimezoneOffset() * 60_000)
                   .toISOString().slice(0, 16);
                 onChange({ ...config, startTime: local });
               }}
               className="text-[10px] font-mono text-skin-gold/70 hover:text-skin-gold border border-skin-gold/20 rounded-lg px-2 py-1 transition-all"
             >
-              Set to now + 2 min
+              Set to now + 5 min
             </button>
           )}
           <p className="text-[8px] font-mono text-skin-dim/30">

--- a/apps/lobby/app/enter/[code]/route.ts
+++ b/apps/lobby/app/enter/[code]/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDB, getEnv } from '@/lib/db';
+import { getSession, generateToken, setSessionCookie } from '@/lib/auth';
+import { verifyGameToken } from '@pecking-order/auth';
+
+// Smart-recovery endpoint. The client's recovery cascade lands here when
+// all local token paths failed. POST with `hint=<any-signature-valid-JWT>`
+// restores identity for that JWT's `sub` — crucial for the "I played game
+// A last month, you shared game B with me" scenario where cached tokens
+// expired but the user is still legitimately that identity.
+// See docs/plans/2026-04-24-auth-flow-hardening.md Task 6.
+
+const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+// GET with no hint: route the visitor based on session. Handles odd
+// arrivals (bookmark, bad redirect) — the real work happens on POST.
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ code: string }> },
+) {
+  const { code } = await params;
+  const session = await getSession();
+  if (session) return NextResponse.redirect(new URL(`/play/${code}`, req.url));
+  return NextResponse.redirect(new URL(`/j/${code}`, req.url));
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ code: string }> },
+) {
+  const { code } = await params;
+  const formData = await req.formData();
+  const hint = (formData.get('hint') as string | null) || null;
+
+  const db = await getDB();
+  const env = await getEnv();
+  const AUTH_SECRET = (env.AUTH_SECRET as string) || 'dev-secret-change-me';
+
+  // Short-circuit if the visitor already has a live session — no identity
+  // restoration needed, just route them to the game.
+  const session = await getSession();
+  if (session) {
+    return NextResponse.redirect(new URL(`/play/${code}`, req.url), 303);
+  }
+
+  const game = await db
+    .prepare('SELECT id, status FROM GameSessions WHERE invite_code = ?')
+    .bind(code.toUpperCase())
+    .first<{ id: string; status: string }>();
+  if (!game) {
+    return NextResponse.redirect(
+      new URL('/login?error=Game+not+found', req.url),
+      303,
+    );
+  }
+
+  if (hint) {
+    try {
+      const decoded = await verifyGameToken(hint, AUTH_SECRET, {
+        ignoreExpiration: true,
+      });
+      const user = await db
+        .prepare('SELECT id FROM Users WHERE id = ?')
+        .bind(decoded.sub)
+        .first<{ id: string }>();
+      if (user) {
+        const sessionId = generateToken();
+        const now = Date.now();
+        await db
+          .prepare(
+            'INSERT INTO Sessions (id, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)',
+          )
+          .bind(sessionId, user.id, now + SESSION_EXPIRY_MS, now)
+          .run();
+        await db
+          .prepare('UPDATE Users SET last_login_at = ? WHERE id = ?')
+          .bind(now, user.id)
+          .run();
+        const response = NextResponse.redirect(new URL(`/play/${code}`, req.url), 303);
+        await setSessionCookie(response, sessionId, req.nextUrl.hostname);
+        return response;
+      }
+      // Signature-valid JWT but the referenced user no longer exists —
+      // treat like a missing hint and fall through to welcome.
+    } catch {
+      // Invalid hint (bad signature, malformed) — fall through to welcome
+      // rather than revealing to the caller why it failed.
+    }
+  }
+
+  return NextResponse.redirect(new URL(`/j/${code}`, req.url), 303);
+}

--- a/apps/lobby/app/enter/[code]/route.ts
+++ b/apps/lobby/app/enter/[code]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDB, getEnv } from '@/lib/db';
 import { getSession, generateToken, setSessionCookie } from '@/lib/auth';
+import { log } from '@/lib/log';
 import { verifyGameToken } from '@pecking-order/auth';
 
 // Smart-recovery endpoint. The client's recovery cascade lands here when
@@ -11,16 +12,37 @@ import { verifyGameToken } from '@pecking-order/auth';
 // See docs/plans/2026-04-24-auth-flow-hardening.md Task 6.
 
 const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+const COMPONENT = 'enter-route';
 
-// GET with no hint: route the visitor based on session. Handles odd
-// arrivals (bookmark, bad redirect) — the real work happens on POST.
+async function loadGame(code: string) {
+  const db = await getDB();
+  return db
+    .prepare('SELECT id, status FROM GameSessions WHERE invite_code = ?')
+    .bind(code.toUpperCase())
+    .first<{ id: string; status: string }>();
+}
+
+// GET with no hint: route the visitor based on session and game presence.
+// Handles odd arrivals (bookmark, bad redirect) — the real work happens
+// on POST. Game lookup here mirrors the POST path so a garbage code gets
+// the same /login?error=Game+not+found response regardless of session
+// state (instead of authed users falling through to /play's own 404).
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ code: string }> },
 ) {
   const { code } = await params;
+  const game = await loadGame(code);
+  if (!game) {
+    log('warn', COMPONENT, 'enter.game_not_found', { code, method: 'GET' });
+    return NextResponse.redirect(new URL('/login?error=Game+not+found', req.url));
+  }
   const session = await getSession();
-  if (session) return NextResponse.redirect(new URL(`/play/${code}`, req.url));
+  if (session) {
+    log('info', COMPONENT, 'enter.session_short_circuit', { code, method: 'GET' });
+    return NextResponse.redirect(new URL(`/play/${code}`, req.url));
+  }
+  log('info', COMPONENT, 'enter.no_session_redirect_welcome', { code, method: 'GET' });
   return NextResponse.redirect(new URL(`/j/${code}`, req.url));
 }
 
@@ -32,26 +54,28 @@ export async function POST(
   const formData = await req.formData();
   const hint = (formData.get('hint') as string | null) || null;
 
-  const db = await getDB();
   const env = await getEnv();
   const AUTH_SECRET = (env.AUTH_SECRET as string) || 'dev-secret-change-me';
+
+  const game = await loadGame(code);
+  if (!game) {
+    log('warn', COMPONENT, 'enter.game_not_found', {
+      code,
+      method: 'POST',
+      hasHint: !!hint,
+    });
+    return NextResponse.redirect(
+      new URL('/login?error=Game+not+found', req.url),
+      303,
+    );
+  }
 
   // Short-circuit if the visitor already has a live session — no identity
   // restoration needed, just route them to the game.
   const session = await getSession();
   if (session) {
+    log('info', COMPONENT, 'enter.session_short_circuit', { code, method: 'POST' });
     return NextResponse.redirect(new URL(`/play/${code}`, req.url), 303);
-  }
-
-  const game = await db
-    .prepare('SELECT id, status FROM GameSessions WHERE invite_code = ?')
-    .bind(code.toUpperCase())
-    .first<{ id: string; status: string }>();
-  if (!game) {
-    return NextResponse.redirect(
-      new URL('/login?error=Game+not+found', req.url),
-      303,
-    );
   }
 
   if (hint) {
@@ -59,33 +83,46 @@ export async function POST(
       const decoded = await verifyGameToken(hint, AUTH_SECRET, {
         ignoreExpiration: true,
       });
+      const db = await getDB();
       const user = await db
         .prepare('SELECT id FROM Users WHERE id = ?')
         .bind(decoded.sub)
         .first<{ id: string }>();
-      if (user) {
-        const sessionId = generateToken();
-        const now = Date.now();
-        await db
-          .prepare(
-            'INSERT INTO Sessions (id, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)',
-          )
-          .bind(sessionId, user.id, now + SESSION_EXPIRY_MS, now)
-          .run();
-        await db
-          .prepare('UPDATE Users SET last_login_at = ? WHERE id = ?')
-          .bind(now, user.id)
-          .run();
-        const response = NextResponse.redirect(new URL(`/play/${code}`, req.url), 303);
-        await setSessionCookie(response, sessionId, req.nextUrl.hostname);
-        return response;
+      if (!user) {
+        log('warn', COMPONENT, 'enter.hint_user_missing', { code, sub: decoded.sub });
+        return NextResponse.redirect(new URL(`/j/${code}`, req.url), 303);
       }
-      // Signature-valid JWT but the referenced user no longer exists —
-      // treat like a missing hint and fall through to welcome.
-    } catch {
-      // Invalid hint (bad signature, malformed) — fall through to welcome
-      // rather than revealing to the caller why it failed.
+      const sessionId = generateToken();
+      const now = Date.now();
+      await db
+        .prepare(
+          'INSERT INTO Sessions (id, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)',
+        )
+        .bind(sessionId, user.id, now + SESSION_EXPIRY_MS, now)
+        .run();
+      await db
+        .prepare('UPDATE Users SET last_login_at = ? WHERE id = ?')
+        .bind(now, user.id)
+        .run();
+      log('info', COMPONENT, 'enter.hint_accepted', {
+        code,
+        sub: decoded.sub,
+        // `exp` is seconds-since-epoch; null when the token predates the claim.
+        exp: decoded.exp ?? null,
+      });
+      const response = NextResponse.redirect(new URL(`/play/${code}`, req.url), 303);
+      await setSessionCookie(response, sessionId, req.nextUrl.hostname);
+      return response;
+    } catch (err) {
+      // Bad signature / malformed / any jose failure. Don't reveal why to
+      // the caller; drop to the welcome view and let them re-enter fresh.
+      log('warn', COMPONENT, 'enter.hint_rejected', {
+        code,
+        reason: err instanceof Error ? err.name : 'unknown',
+      });
     }
+  } else {
+    log('info', COMPONENT, 'enter.no_hint', { code });
   }
 
   return NextResponse.redirect(new URL(`/j/${code}`, req.url), 303);

--- a/apps/lobby/app/game/[id]/waiting/page.tsx
+++ b/apps/lobby/app/game/[id]/waiting/page.tsx
@@ -112,16 +112,23 @@ export default function WaitingRoom() {
     }
   }
 
+  // Canonical share URL is /j/CODE — the frictionless welcome, not the
+  // auth-walled /join/CODE. Strangers who tap the shared link land on a
+  // welcome form instead of the magic-link wall.
+  const shareLink =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}/j/${code.toUpperCase()}`
+      : '';
+
   async function handleCopyLink() {
-    const link = `${window.location.origin}/join/${code.toUpperCase()}`;
     try {
-      await navigator.clipboard.writeText(link);
+      await navigator.clipboard.writeText(shareLink);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
       // Fallback for older browsers
       const textarea = document.createElement('textarea');
-      textarea.value = link;
+      textarea.value = shareLink;
       document.body.appendChild(textarea);
       textarea.select();
       document.execCommand('copy');
@@ -175,16 +182,24 @@ export default function WaitingRoom() {
           <h1 className="text-3xl md:text-5xl font-display font-black tracking-tighter text-skin-gold text-glow">
             PECKING ORDER
           </h1>
-          <div className="flex items-center justify-center gap-2">
-            <p className="text-sm text-skin-dim font-mono">
-              Game: <span className="text-skin-gold font-bold tracking-wider">{code.toUpperCase()}</span>
-            </p>
-            <button
-              onClick={handleCopyLink}
-              className="text-xs font-mono px-2 py-1 rounded-md border border-skin-base/50 text-skin-dim hover:text-skin-base hover:border-skin-gold/50 transition-all"
-            >
-              {copied ? 'Copied!' : 'Copy Link'}
-            </button>
+          <p className="text-sm text-skin-dim font-mono">
+            Game: <span className="text-skin-gold font-bold tracking-wider">{code.toUpperCase()}</span>
+          </p>
+          <div className="mt-2 max-w-sm mx-auto space-y-1.5">
+            <div className="text-[10px] font-bold text-skin-dim uppercase tracking-widest text-left">
+              Invite link
+            </div>
+            <div className="flex items-center gap-2 p-2 rounded-lg bg-skin-input/60">
+              <code className="flex-1 text-xs font-mono text-skin-base truncate text-left">
+                {shareLink}
+              </code>
+              <button
+                onClick={handleCopyLink}
+                className="text-xs font-bold text-skin-gold px-2 py-1 rounded border border-skin-gold/30 hover:border-skin-gold/60 transition-all whitespace-nowrap"
+              >
+                {copied ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
           </div>
         </header>
 

--- a/apps/lobby/app/invite/[token]/route.ts
+++ b/apps/lobby/app/invite/[token]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDB } from '@/lib/db';
 import { generateToken, setSessionCookie } from '@/lib/auth';
+import { log } from '@/lib/log';
+import { renderConfirmPage } from '@/lib/render-confirm-page';
 
 // Bot-safe render: GET validates (read-only) + renders an auto-submitting
 // confirm page. POST consumes the invite token, upserts user, mints session,
@@ -10,20 +12,7 @@ import { generateToken, setSessionCookie } from '@/lib/auth';
 // See docs/plans/2026-04-24-auth-flow-hardening.md Task 1.
 
 const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
-
-// Log an invite-flow event as structured JSON (Axiom picks it up from
-// Workers Logs). tokenPrefix gives enough correlation to join against the
-// InviteTokens.token column in D1 without writing the full secret to logs.
-function logInvite(
-  level: 'info' | 'warn' | 'error',
-  event: string,
-  tokenPrefix: string,
-  extra?: Record<string, unknown>,
-) {
-  console.log(
-    JSON.stringify({ level, component: 'invite-route', event, tokenPrefix, ...extra }),
-  );
-}
+const COMPONENT = 'invite-route';
 
 type Invite = {
   token: string;
@@ -45,40 +34,13 @@ async function loadInvite(token: string): Promise<Invite | null> {
     .first<Invite>();
 }
 
-function renderConfirmPage(token: string, inviteCode: string): Response {
-  // token is a 64-hex string and inviteCode is [A-Z0-9], both looked up in
-  // D1. Re-encoding defensively before embedding in HTML attributes.
-  const safeToken = encodeURIComponent(token);
-  const safeCode = encodeURIComponent(inviteCode);
-  const html = [
-    '<!doctype html><html lang="en"><head>',
-    '<meta charset="utf-8">',
-    '<meta name="viewport" content="width=device-width,initial-scale=1">',
-    '<title>Continue to Pecking Order</title>',
-    '<style>',
-    'body{margin:0;font-family:system-ui,sans-serif;background:#0f0a1a;color:#fff;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}',
-    '.card{max-width:360px;text-align:center}',
-    '.spinner{width:24px;height:24px;margin:0 auto 16px;border:2px solid #f5c842;border-top-color:transparent;border-radius:50%;animation:spin 0.8s linear infinite}',
-    'button{margin-top:16px;padding:14px 24px;background:#f5c842;color:#0f0a1a;border:0;border-radius:12px;font-weight:700;cursor:pointer;font-size:15px}',
-    '@keyframes spin{to{transform:rotate(360deg)}}',
-    '</style></head><body>',
-    '<div class="card">',
-    '<div class="spinner" aria-hidden="true"></div>',
-    '<p>Taking you to your game…</p>',
-    `<form method="post" action="/invite/${safeToken}" id="f">`,
-    '<noscript>',
-    `<button type="submit">Continue to game ${safeCode}</button>`,
-    '</noscript>',
-    `<button id="fallback" type="submit" style="display:none">Continue to game ${safeCode}</button>`,
-    '</form>',
-    // Auto-submit after 150ms so the spinner renders first. If the POST
-    // doesn't complete within 3s, reveal a manual button so the user
-    // isn't stranded on a flaky connection.
-    '<script>setTimeout(function(){var f=document.getElementById("f");if(f)f.submit()},150);',
-    'setTimeout(function(){var n=document.getElementById("fallback");if(n)n.style.display="block"},3000);</script>',
-    '</div></body></html>',
-  ].join('');
-  return new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+function inviteConfirmPage(token: string, inviteCode: string): Response {
+  return renderConfirmPage({
+    title: 'Continue to Pecking Order',
+    bodyCopy: 'Taking you to your game…',
+    formAction: `/invite/${encodeURIComponent(token)}`,
+    continueLabel: `Continue to game ${inviteCode}`,
+  });
 }
 
 export async function GET(
@@ -90,19 +52,19 @@ export async function GET(
   const invite = await loadInvite(token);
   const now = Date.now();
   if (!invite) {
-    logInvite('warn', 'invite.invalid', tokenPrefix, { method: 'GET' });
+    log('warn', COMPONENT, 'invite.invalid', { tokenPrefix, method: 'GET' });
     return NextResponse.redirect(new URL('/login?error=Invalid+invite+link', req.url));
   }
   if (invite.expires_at < now) {
-    logInvite('info', 'invite.expired', tokenPrefix, { method: 'GET' });
+    log('info', COMPONENT, 'invite.expired', { tokenPrefix, method: 'GET' });
     return NextResponse.redirect(new URL('/login?error=Invite+link+expired', req.url));
   }
   if (invite.used) {
-    logInvite('info', 'invite.already_used', tokenPrefix, { method: 'GET' });
+    log('info', COMPONENT, 'invite.already_used', { tokenPrefix, method: 'GET' });
     return NextResponse.redirect(new URL(`/j/${invite.invite_code}`, req.url));
   }
-  logInvite('info', 'invite.confirm_page_rendered', tokenPrefix);
-  return renderConfirmPage(token, invite.invite_code);
+  log('info', COMPONENT, 'invite.confirm_page_rendered', { tokenPrefix });
+  return inviteConfirmPage(token, invite.invite_code);
 }
 
 export async function POST(
@@ -114,15 +76,15 @@ export async function POST(
   const invite = await loadInvite(token);
   const now = Date.now();
   if (!invite) {
-    logInvite('warn', 'invite.invalid', tokenPrefix, { method: 'POST' });
+    log('warn', COMPONENT, 'invite.invalid', { tokenPrefix, method: 'POST' });
     return NextResponse.redirect(new URL('/login?error=Invalid+invite+link', req.url), 303);
   }
   if (invite.expires_at < now) {
-    logInvite('info', 'invite.expired', tokenPrefix, { method: 'POST' });
+    log('info', COMPONENT, 'invite.expired', { tokenPrefix, method: 'POST' });
     return NextResponse.redirect(new URL('/login?error=Invite+link+expired', req.url), 303);
   }
   if (invite.used) {
-    logInvite('info', 'invite.already_used', tokenPrefix, { method: 'POST' });
+    log('info', COMPONENT, 'invite.already_used', { tokenPrefix, method: 'POST' });
     return NextResponse.redirect(new URL(`/j/${invite.invite_code}`, req.url), 303);
   }
 
@@ -136,7 +98,7 @@ export async function POST(
     .bind(token)
     .run();
   if ((updateResult.meta?.changes ?? 0) === 0) {
-    logInvite('info', 'invite.already_used', tokenPrefix, { method: 'POST', race: true });
+    log('info', COMPONENT, 'invite.already_used', { tokenPrefix, method: 'POST', race: true });
     return NextResponse.redirect(new URL(`/j/${invite.invite_code}`, req.url), 303);
   }
 
@@ -161,7 +123,8 @@ export async function POST(
     .bind(sessionId, user.id, now + SESSION_EXPIRY_MS, now)
     .run();
 
-  logInvite('info', 'invite.consumed', tokenPrefix, {
+  log('info', COMPONENT, 'invite.consumed', {
+    tokenPrefix,
     inviteCode: invite.invite_code,
     gameId: invite.game_id,
   });

--- a/apps/lobby/app/invite/[token]/route.ts
+++ b/apps/lobby/app/invite/[token]/route.ts
@@ -11,6 +11,20 @@ import { generateToken, setSessionCookie } from '@/lib/auth';
 
 const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 
+// Log an invite-flow event as structured JSON (Axiom picks it up from
+// Workers Logs). tokenPrefix gives enough correlation to join against the
+// InviteTokens.token column in D1 without writing the full secret to logs.
+function logInvite(
+  level: 'info' | 'warn' | 'error',
+  event: string,
+  tokenPrefix: string,
+  extra?: Record<string, unknown>,
+) {
+  console.log(
+    JSON.stringify({ level, component: 'invite-route', event, tokenPrefix, ...extra }),
+  );
+}
+
 type Invite = {
   token: string;
   email: string;
@@ -72,17 +86,22 @@ export async function GET(
   { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
+  const tokenPrefix = token.slice(0, 8);
   const invite = await loadInvite(token);
   const now = Date.now();
   if (!invite) {
+    logInvite('warn', 'invite.invalid', tokenPrefix, { method: 'GET' });
     return NextResponse.redirect(new URL('/login?error=Invalid+invite+link', req.url));
   }
   if (invite.expires_at < now) {
+    logInvite('info', 'invite.expired', tokenPrefix, { method: 'GET' });
     return NextResponse.redirect(new URL('/login?error=Invite+link+expired', req.url));
   }
   if (invite.used) {
+    logInvite('info', 'invite.already_used', tokenPrefix, { method: 'GET' });
     return NextResponse.redirect(new URL(`/j/${invite.invite_code}`, req.url));
   }
+  logInvite('info', 'invite.confirm_page_rendered', tokenPrefix);
   return renderConfirmPage(token, invite.invite_code);
 }
 
@@ -91,15 +110,19 @@ export async function POST(
   { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
+  const tokenPrefix = token.slice(0, 8);
   const invite = await loadInvite(token);
   const now = Date.now();
   if (!invite) {
+    logInvite('warn', 'invite.invalid', tokenPrefix, { method: 'POST' });
     return NextResponse.redirect(new URL('/login?error=Invalid+invite+link', req.url), 303);
   }
   if (invite.expires_at < now) {
+    logInvite('info', 'invite.expired', tokenPrefix, { method: 'POST' });
     return NextResponse.redirect(new URL('/login?error=Invite+link+expired', req.url), 303);
   }
   if (invite.used) {
+    logInvite('info', 'invite.already_used', tokenPrefix, { method: 'POST' });
     return NextResponse.redirect(new URL(`/j/${invite.invite_code}`, req.url), 303);
   }
 
@@ -127,6 +150,10 @@ export async function POST(
     .bind(sessionId, user.id, now + SESSION_EXPIRY_MS, now)
     .run();
 
+  logInvite('info', 'invite.consumed', tokenPrefix, {
+    inviteCode: invite.invite_code,
+    gameId: invite.game_id,
+  });
   const response = NextResponse.redirect(new URL(`/join/${invite.invite_code}`, req.url), 303);
   await setSessionCookie(response, sessionId, req.nextUrl.hostname);
   return response;

--- a/apps/lobby/app/invite/[token]/route.ts
+++ b/apps/lobby/app/invite/[token]/route.ts
@@ -127,7 +127,18 @@ export async function POST(
   }
 
   const db = await getDB();
-  await db.prepare('UPDATE InviteTokens SET used = 1 WHERE token = ?').bind(token).run();
+  // Race-safe consume: guard on used = 0 so two concurrent POSTs (browser
+  // double-tap, auto-submit + user tap, two tabs) don't both mint sessions.
+  // If meta.changes is 0, someone else consumed the token between our
+  // loadInvite() read and this UPDATE — treat as already-used.
+  const updateResult = await db
+    .prepare('UPDATE InviteTokens SET used = 1 WHERE token = ? AND used = 0')
+    .bind(token)
+    .run();
+  if ((updateResult.meta?.changes ?? 0) === 0) {
+    logInvite('info', 'invite.already_used', tokenPrefix, { method: 'POST', race: true });
+    return NextResponse.redirect(new URL(`/j/${invite.invite_code}`, req.url), 303);
+  }
 
   const normalizedEmail = invite.email.toLowerCase().trim();
   let user = await db

--- a/apps/lobby/app/invite/[token]/route.ts
+++ b/apps/lobby/app/invite/[token]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDB } from '@/lib/db';
 import { generateToken, setSessionCookie } from '@/lib/auth';
-import { log } from '@/lib/log';
+import { log, LOG_TOKEN_PREFIX_LEN } from '@/lib/log';
 import { renderConfirmPage } from '@/lib/render-confirm-page';
 
 // Bot-safe render: GET validates (read-only) + renders an auto-submitting
@@ -48,7 +48,7 @@ export async function GET(
   { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
-  const tokenPrefix = token.slice(0, 8);
+  const tokenPrefix = token.slice(0, LOG_TOKEN_PREFIX_LEN);
   const invite = await loadInvite(token);
   const now = Date.now();
   if (!invite) {
@@ -72,7 +72,7 @@ export async function POST(
   { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
-  const tokenPrefix = token.slice(0, 8);
+  const tokenPrefix = token.slice(0, LOG_TOKEN_PREFIX_LEN);
   const invite = await loadInvite(token);
   const now = Date.now();
   if (!invite) {

--- a/apps/lobby/app/invite/[token]/route.ts
+++ b/apps/lobby/app/invite/[token]/route.ts
@@ -1,55 +1,116 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDB } from '@/lib/db';
-import { generateToken, getSessionCookieName } from '@/lib/auth';
+import { generateToken, setSessionCookie } from '@/lib/auth';
 
-const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+// Bot-safe render: GET validates (read-only) + renders an auto-submitting
+// confirm page. POST consumes the invite token, upserts user, mints session,
+// and redirects to the join flow. Defends against email-security scanners
+// (Mimecast/Proofpoint/iOS preview) that GET-prefetch invite URLs and were
+// orphaning tokens before real users could click.
+// See docs/plans/2026-04-24-auth-flow-hardening.md Task 1.
 
-export async function GET(req: NextRequest, { params }: { params: Promise<{ token: string }> }) {
-  const { token } = await params;
+const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+type Invite = {
+  token: string;
+  email: string;
+  game_id: string;
+  invite_code: string;
+  expires_at: number;
+  used: number;
+};
+
+async function loadInvite(token: string): Promise<Invite | null> {
   const db = await getDB();
-  const now = Date.now();
-
-  // Look up invite token
-  const invite = await db
+  return db
     .prepare(
       `SELECT token, email, game_id, invite_code, expires_at, used
-       FROM InviteTokens WHERE token = ?`
+       FROM InviteTokens WHERE token = ?`,
     )
     .bind(token)
-    .first<{
-      token: string;
-      email: string;
-      game_id: string;
-      invite_code: string;
-      expires_at: number;
-      used: number;
-    }>();
+    .first<Invite>();
+}
 
+function renderConfirmPage(token: string, inviteCode: string): Response {
+  // token is a 64-hex string and inviteCode is [A-Z0-9], both looked up in
+  // D1. Re-encoding defensively before embedding in HTML attributes.
+  const safeToken = encodeURIComponent(token);
+  const safeCode = encodeURIComponent(inviteCode);
+  const html = [
+    '<!doctype html><html lang="en"><head>',
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width,initial-scale=1">',
+    '<title>Continue to Pecking Order</title>',
+    '<style>',
+    'body{margin:0;font-family:system-ui,sans-serif;background:#0f0a1a;color:#fff;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}',
+    '.card{max-width:360px;text-align:center}',
+    '.spinner{width:24px;height:24px;margin:0 auto 16px;border:2px solid #f5c842;border-top-color:transparent;border-radius:50%;animation:spin 0.8s linear infinite}',
+    'button{margin-top:16px;padding:14px 24px;background:#f5c842;color:#0f0a1a;border:0;border-radius:12px;font-weight:700;cursor:pointer;font-size:15px}',
+    '@keyframes spin{to{transform:rotate(360deg)}}',
+    '</style></head><body>',
+    '<div class="card">',
+    '<div class="spinner" aria-hidden="true"></div>',
+    '<p>Taking you to your game…</p>',
+    `<form method="post" action="/invite/${safeToken}" id="f">`,
+    '<noscript>',
+    `<button type="submit">Continue to game ${safeCode}</button>`,
+    '</noscript>',
+    `<button id="fallback" type="submit" style="display:none">Continue to game ${safeCode}</button>`,
+    '</form>',
+    // Auto-submit after 150ms so the spinner renders first. If the POST
+    // doesn't complete within 3s, reveal a manual button so the user
+    // isn't stranded on a flaky connection.
+    '<script>setTimeout(function(){var f=document.getElementById("f");if(f)f.submit()},150);',
+    'setTimeout(function(){var n=document.getElementById("fallback");if(n)n.style.display="block"},3000);</script>',
+    '</div></body></html>',
+  ].join('');
+  return new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+  const invite = await loadInvite(token);
+  const now = Date.now();
   if (!invite) {
-    return NextResponse.redirect(new URL('/login?error=Invalid invite link', req.url));
+    return NextResponse.redirect(new URL('/login?error=Invalid+invite+link', req.url));
   }
-
-  if (invite.used) {
-    // Already used — redirect to join page anyway (they might already be in the game)
-    return NextResponse.redirect(new URL(`/join/${invite.invite_code}`, req.url));
-  }
-
   if (invite.expires_at < now) {
-    const errorUrl = new URL('/login', req.url);
-    errorUrl.searchParams.set('error', 'Invite link expired');
-    return NextResponse.redirect(errorUrl);
+    return NextResponse.redirect(new URL('/login?error=Invite+link+expired', req.url));
+  }
+  if (invite.used) {
+    return NextResponse.redirect(new URL(`/j/${invite.invite_code}`, req.url));
+  }
+  return renderConfirmPage(token, invite.invite_code);
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+  const invite = await loadInvite(token);
+  const now = Date.now();
+  if (!invite) {
+    return NextResponse.redirect(new URL('/login?error=Invalid+invite+link', req.url), 303);
+  }
+  if (invite.expires_at < now) {
+    return NextResponse.redirect(new URL('/login?error=Invite+link+expired', req.url), 303);
+  }
+  if (invite.used) {
+    return NextResponse.redirect(new URL(`/j/${invite.invite_code}`, req.url), 303);
   }
 
-  // Mark as used
+  const db = await getDB();
   await db.prepare('UPDATE InviteTokens SET used = 1 WHERE token = ?').bind(token).run();
 
-  // Upsert user for this email
   const normalizedEmail = invite.email.toLowerCase().trim();
   let user = await db
     .prepare('SELECT id FROM Users WHERE email = ?')
     .bind(normalizedEmail)
     .first<{ id: string }>();
-
   if (!user) {
     const userId = crypto.randomUUID();
     await db
@@ -58,29 +119,15 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ toke
       .run();
     user = { id: userId };
   }
-
-  // Update last login
   await db.prepare('UPDATE Users SET last_login_at = ? WHERE id = ?').bind(now, user.id).run();
 
-  // Create session
   const sessionId = generateToken();
   await db
     .prepare('INSERT INTO Sessions (id, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)')
     .bind(sessionId, user.id, now + SESSION_EXPIRY_MS, now)
     .run();
 
-  // Redirect to join page with session cookie
-  const cookieName = await getSessionCookieName();
-  const response = NextResponse.redirect(new URL(`/join/${invite.invite_code}`, req.url));
-  const host = req.nextUrl.hostname;
-  const isLocal = host === 'localhost' || host === '127.0.0.1';
-  response.cookies.set(cookieName, sessionId, {
-    httpOnly: true,
-    secure: !isLocal,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 7 * 24 * 60 * 60,
-    ...(isLocal ? {} : { domain: '.peckingorder.ca' }),
-  });
+  const response = NextResponse.redirect(new URL(`/join/${invite.invite_code}`, req.url), 303);
+  await setSessionCookie(response, sessionId, req.nextUrl.hostname);
   return response;
 }

--- a/apps/lobby/app/j/[code]/actions.ts
+++ b/apps/lobby/app/j/[code]/actions.ts
@@ -1,9 +1,9 @@
 'use server';
 
-import { cookies, headers } from 'next/headers';
+import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { getDB } from '@/lib/db';
-import { getSession, generateId, generateToken, getSessionCookieName } from '@/lib/auth';
+import { getSession, generateId, generateToken, setSessionCookieOnRequest } from '@/lib/auth';
 import { checkAnonymousRateLimit, recordAnonymousCreate } from '@/lib/rate-limit';
 
 const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days, mirrors lib/auth.ts
@@ -106,16 +106,10 @@ export async function claimSeat(
   // Record rate-limit tally AFTER successful commit.
   await recordAnonymousCreate(db, ip);
 
-  // Set cookie.
-  const cookieName = await getSessionCookieName();
-  const cookieStore = await cookies();
-  cookieStore.set(cookieName, sessionId, {
-    httpOnly: true,
-    secure: true,
-    sameSite: 'lax',
-    maxAge: SESSION_EXPIRY_MS / 1000,
-    path: '/',
-  });
+  // Set session cookie via shared helper — adapts `secure` to the request
+  // hostname so HTTP responses in mixed-HTTPS environments don't strip it.
+  const hostname = hdrs.get('host')?.split(':')[0] || '';
+  await setSessionCookieOnRequest(sessionId, hostname);
 
   // Redirect into the existing persona wizard.
   redirect(`/join/${code}`);

--- a/apps/lobby/app/j/[code]/page.tsx
+++ b/apps/lobby/app/j/[code]/page.tsx
@@ -1,5 +1,6 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { getDB, getEnv } from '@/lib/db';
+import { getSession } from '@/lib/auth';
 import { WelcomeForm } from './welcome-form';
 import { JoinedCast } from './joined-cast';
 import { buildSocialLine, displayLabelFor, type JoinedPlayer } from './cast-helpers';
@@ -39,6 +40,22 @@ export default async function FrictionlessWelcomePage({ params }: PageProps) {
         </div>
       </div>
     );
+  }
+
+  // Short-circuit based on visitor session. Anon visitors fall through to
+  // the welcome form below. Authed players either continue into /play
+  // (already enrolled) or /join (need persona pick).
+  // D1 is eventually-consistent across replicas; an Invites row written
+  // sub-second ago might miss here and show the welcome form instead of
+  // redirecting. The next reload picks it up. Acceptable residual gap.
+  const session = await getSession();
+  if (session) {
+    const enrolled = await db
+      .prepare('SELECT id FROM Invites WHERE game_id = ? AND accepted_by = ?')
+      .bind(game.id, session.userId)
+      .first();
+    if (enrolled) redirect(`/play/${code}`);
+    redirect(`/join/${code}`);
   }
 
   // Joined cast: fetch up to 6 accepted players with persona + user labels,

--- a/apps/lobby/app/j/[code]/page.tsx
+++ b/apps/lobby/app/j/[code]/page.tsx
@@ -42,20 +42,25 @@ export default async function FrictionlessWelcomePage({ params }: PageProps) {
     );
   }
 
-  // Short-circuit based on visitor session. Anon visitors fall through to
-  // the welcome form below. Authed players either continue into /play
-  // (already enrolled) or /join (need persona pick).
+  // Short-circuit based on visitor session:
+  //   authed + not enrolled    → /join (persona pick)
+  //   authed + enrolled + STARTED → /play (into the running game)
+  //   anon OR authed + enrolled + pre-start → fall through to the welcome
+  //     view so the visitor sees the joined cast + social context. /play
+  //     would bounce pre-start players into /game/CODE/waiting (host
+  //     panel, reads as empty for non-host enrolled players).
   // D1 is eventually-consistent across replicas; an Invites row written
   // sub-second ago might miss here and show the welcome form instead of
-  // redirecting. The next reload picks it up. Acceptable residual gap.
+  // redirecting. Next reload picks it up. Acceptable residual gap.
   const session = await getSession();
   if (session) {
     const enrolled = await db
       .prepare('SELECT id FROM Invites WHERE game_id = ? AND accepted_by = ?')
       .bind(game.id, session.userId)
       .first();
-    if (enrolled) redirect(`/play/${code}`);
-    redirect(`/join/${code}`);
+    if (!enrolled) redirect(`/join/${code}`);
+    if (game.status === 'STARTED') redirect(`/play/${code}`);
+    // enrolled + RECRUITING/READY → render the welcome view below.
   }
 
   // Joined cast: fetch up to 6 accepted players with persona + user labels,

--- a/apps/lobby/app/login/verify/route.ts
+++ b/apps/lobby/app/login/verify/route.ts
@@ -1,5 +1,42 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyMagicLink, getSessionCookieName } from '@/lib/auth';
+import { verifyMagicLink, setSessionCookie } from '@/lib/auth';
+
+// Bot-safe render: GET renders a tiny auto-submitting confirm page (no token
+// consumption). POST consumes the magic link + sets session cookie. Defends
+// against email-security-scanner prefetch that was orphaning tokens.
+// See docs/plans/2026-04-24-auth-flow-hardening.md Task 2.
+
+function renderConfirmPage(token: string, next: string): Response {
+  // token, next are url-safe primitives that we re-encode before embedding.
+  const safeToken = encodeURIComponent(token);
+  const safeNext = encodeURIComponent(next);
+  const html = [
+    '<!doctype html><html lang="en"><head>',
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width,initial-scale=1">',
+    '<title>Signing you in…</title>',
+    '<style>',
+    'body{margin:0;font-family:system-ui,sans-serif;background:#0f0a1a;color:#fff;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}',
+    '.card{max-width:360px;text-align:center}',
+    '.spinner{width:24px;height:24px;margin:0 auto 16px;border:2px solid #f5c842;border-top-color:transparent;border-radius:50%;animation:spin 0.8s linear infinite}',
+    'button{margin-top:16px;padding:14px 24px;background:#f5c842;color:#0f0a1a;border:0;border-radius:12px;font-weight:700;cursor:pointer;font-size:15px}',
+    '@keyframes spin{to{transform:rotate(360deg)}}',
+    '</style></head><body>',
+    '<div class="card">',
+    '<div class="spinner" aria-hidden="true"></div>',
+    '<p>Signing you in…</p>',
+    '<form method="post" action="/login/verify" id="f">',
+    `<input type="hidden" name="token" value="${safeToken}">`,
+    `<input type="hidden" name="next" value="${safeNext}">`,
+    '<noscript><button type="submit">Continue to sign in</button></noscript>',
+    '<button id="fallback" type="submit" style="display:none">Continue to sign in</button>',
+    '</form>',
+    '<script>setTimeout(function(){var f=document.getElementById("f");if(f)f.submit()},150);',
+    'setTimeout(function(){var n=document.getElementById("fallback");if(n)n.style.display="block"},3000);</script>',
+    '</div></body></html>',
+  ].join('');
+  return new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
 
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token');
@@ -9,26 +46,30 @@ export async function GET(req: NextRequest) {
     return NextResponse.redirect(new URL('/login', req.url));
   }
 
+  // Intentionally render the confirm page without hitting D1 — we want
+  // scanner GETs to be cheap and side-effect-free. Any token validity
+  // check is deferred to POST.
+  return renderConfirmPage(token, next);
+}
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+  const token = (formData.get('token') as string | null) ?? '';
+  const next = (formData.get('next') as string | null) || '/';
+
+  if (!token) {
+    return NextResponse.redirect(new URL('/login', req.url), 303);
+  }
+
   const result = await verifyMagicLink(token);
 
   if (result.success && result.sessionId) {
-    const cookieName = await getSessionCookieName();
-    const response = NextResponse.redirect(new URL(next, req.url));
-    const host = req.nextUrl.hostname;
-    const isLocal = host === 'localhost' || host === '127.0.0.1';
-    response.cookies.set(cookieName, result.sessionId, {
-      httpOnly: true,
-      secure: !isLocal,
-      sameSite: 'lax',
-      path: '/',
-      maxAge: 7 * 24 * 60 * 60, // 7 days in seconds
-      ...(isLocal ? {} : { domain: '.peckingorder.ca' }),
-    });
+    const response = NextResponse.redirect(new URL(next, req.url), 303);
+    await setSessionCookie(response, result.sessionId, req.nextUrl.hostname);
     return response;
   }
 
-  // Verification failed — redirect to login with error
   const errorUrl = new URL('/login', req.url);
   errorUrl.searchParams.set('error', result.error || 'Verification failed');
-  return NextResponse.redirect(errorUrl);
+  return NextResponse.redirect(errorUrl, 303);
 }

--- a/apps/lobby/app/login/verify/route.ts
+++ b/apps/lobby/app/login/verify/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyMagicLink, setSessionCookie } from '@/lib/auth';
-import { log } from '@/lib/log';
+import { log, LOG_TOKEN_PREFIX_LEN } from '@/lib/log';
 import { renderConfirmPage } from '@/lib/render-confirm-page';
 
 // Bot-safe render: GET renders a tiny auto-submitting confirm page (no token
@@ -10,6 +10,22 @@ import { renderConfirmPage } from '@/lib/render-confirm-page';
 
 const COMPONENT = 'magic-link-route';
 const MISSING_TOKEN_PREFIX = '<missing>';
+
+// Reject anything that isn't a strict same-origin relative path. An
+// unchecked `next=//evil.com` would resolve to https://evil.com once
+// fed through `new URL(next, req.url)` — a post-auth open redirect.
+// Valid: "/", "/admin", "/j/CODE". Invalid: "//evil.com",
+// "/\\evil.com", "https://evil.com", "". Any reject falls back to "/".
+function safeRelativeNext(raw: string | null | undefined): string {
+  if (!raw || typeof raw !== 'string') return '/';
+  if (!raw.startsWith('/')) return '/';
+  // Protocol-relative (//host) or backslash-prefixed (browsers normalize
+  // \\ to //) both resolve cross-origin.
+  if (raw.startsWith('//') || raw.startsWith('/\\') || raw.startsWith('/%2f')) {
+    return '/';
+  }
+  return raw;
+}
 
 function magicLinkConfirmPage(token: string, next: string): Response {
   return renderConfirmPage({
@@ -23,7 +39,7 @@ function magicLinkConfirmPage(token: string, next: string): Response {
 
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token');
-  const next = req.nextUrl.searchParams.get('next') || '/';
+  const next = safeRelativeNext(req.nextUrl.searchParams.get('next'));
 
   if (!token) {
     log('warn', COMPONENT, 'magic_link.no_token', {
@@ -37,7 +53,7 @@ export async function GET(req: NextRequest) {
   // scanner GETs to be cheap and side-effect-free. Any token validity
   // check is deferred to POST.
   log('info', COMPONENT, 'magic_link.confirm_page_rendered', {
-    tokenPrefix: token.slice(0, 8),
+    tokenPrefix: token.slice(0, LOG_TOKEN_PREFIX_LEN),
   });
   return magicLinkConfirmPage(token, next);
 }
@@ -45,8 +61,8 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const formData = await req.formData();
   const token = (formData.get('token') as string | null) ?? '';
-  const next = (formData.get('next') as string | null) || '/';
-  const tokenPrefix = token ? token.slice(0, 8) : MISSING_TOKEN_PREFIX;
+  const next = safeRelativeNext(formData.get('next') as string | null);
+  const tokenPrefix = token ? token.slice(0, LOG_TOKEN_PREFIX_LEN) : MISSING_TOKEN_PREFIX;
 
   if (!token) {
     log('warn', COMPONENT, 'magic_link.no_token', { tokenPrefix, method: 'POST' });

--- a/apps/lobby/app/login/verify/route.ts
+++ b/apps/lobby/app/login/verify/route.ts
@@ -6,6 +6,17 @@ import { verifyMagicLink, setSessionCookie } from '@/lib/auth';
 // against email-security-scanner prefetch that was orphaning tokens.
 // See docs/plans/2026-04-24-auth-flow-hardening.md Task 2.
 
+function logMagicLink(
+  level: 'info' | 'warn' | 'error',
+  event: string,
+  tokenPrefix: string,
+  extra?: Record<string, unknown>,
+) {
+  console.log(
+    JSON.stringify({ level, component: 'magic-link-route', event, tokenPrefix, ...extra }),
+  );
+}
+
 function renderConfirmPage(token: string, next: string): Response {
   // token, next are url-safe primitives that we re-encode before embedding.
   const safeToken = encodeURIComponent(token);
@@ -43,12 +54,14 @@ export async function GET(req: NextRequest) {
   const next = req.nextUrl.searchParams.get('next') || '/';
 
   if (!token) {
+    logMagicLink('warn', 'magic_link.no_token', '', { method: 'GET' });
     return NextResponse.redirect(new URL('/login', req.url));
   }
 
   // Intentionally render the confirm page without hitting D1 — we want
   // scanner GETs to be cheap and side-effect-free. Any token validity
   // check is deferred to POST.
+  logMagicLink('info', 'magic_link.confirm_page_rendered', token.slice(0, 8));
   return renderConfirmPage(token, next);
 }
 
@@ -56,18 +69,32 @@ export async function POST(req: NextRequest) {
   const formData = await req.formData();
   const token = (formData.get('token') as string | null) ?? '';
   const next = (formData.get('next') as string | null) || '/';
+  const tokenPrefix = token.slice(0, 8);
 
   if (!token) {
+    logMagicLink('warn', 'magic_link.no_token', '', { method: 'POST' });
     return NextResponse.redirect(new URL('/login', req.url), 303);
   }
 
   const result = await verifyMagicLink(token);
 
   if (result.success && result.sessionId) {
+    logMagicLink('info', 'magic_link.consumed', tokenPrefix);
     const response = NextResponse.redirect(new URL(next, req.url), 303);
     await setSessionCookie(response, result.sessionId, req.nextUrl.hostname);
     return response;
   }
+
+  // Map known error strings to event names for easier log queries.
+  const errorName =
+    result.error === 'Link already used'
+      ? 'magic_link.already_used'
+      : result.error === 'Link expired'
+        ? 'magic_link.expired'
+        : result.error === 'Invalid link'
+          ? 'magic_link.invalid'
+          : 'magic_link.failed';
+  logMagicLink('warn', errorName, tokenPrefix, { error: result.error });
 
   const errorUrl = new URL('/login', req.url);
   errorUrl.searchParams.set('error', result.error || 'Verification failed');

--- a/apps/lobby/app/login/verify/route.ts
+++ b/apps/lobby/app/login/verify/route.ts
@@ -1,52 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyMagicLink, setSessionCookie } from '@/lib/auth';
+import { log } from '@/lib/log';
+import { renderConfirmPage } from '@/lib/render-confirm-page';
 
 // Bot-safe render: GET renders a tiny auto-submitting confirm page (no token
 // consumption). POST consumes the magic link + sets session cookie. Defends
 // against email-security-scanner prefetch that was orphaning tokens.
 // See docs/plans/2026-04-24-auth-flow-hardening.md Task 2.
 
-function logMagicLink(
-  level: 'info' | 'warn' | 'error',
-  event: string,
-  tokenPrefix: string,
-  extra?: Record<string, unknown>,
-) {
-  console.log(
-    JSON.stringify({ level, component: 'magic-link-route', event, tokenPrefix, ...extra }),
-  );
-}
+const COMPONENT = 'magic-link-route';
+const MISSING_TOKEN_PREFIX = '<missing>';
 
-function renderConfirmPage(token: string, next: string): Response {
-  // token, next are url-safe primitives that we re-encode before embedding.
-  const safeToken = encodeURIComponent(token);
-  const safeNext = encodeURIComponent(next);
-  const html = [
-    '<!doctype html><html lang="en"><head>',
-    '<meta charset="utf-8">',
-    '<meta name="viewport" content="width=device-width,initial-scale=1">',
-    '<title>Signing you in…</title>',
-    '<style>',
-    'body{margin:0;font-family:system-ui,sans-serif;background:#0f0a1a;color:#fff;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}',
-    '.card{max-width:360px;text-align:center}',
-    '.spinner{width:24px;height:24px;margin:0 auto 16px;border:2px solid #f5c842;border-top-color:transparent;border-radius:50%;animation:spin 0.8s linear infinite}',
-    'button{margin-top:16px;padding:14px 24px;background:#f5c842;color:#0f0a1a;border:0;border-radius:12px;font-weight:700;cursor:pointer;font-size:15px}',
-    '@keyframes spin{to{transform:rotate(360deg)}}',
-    '</style></head><body>',
-    '<div class="card">',
-    '<div class="spinner" aria-hidden="true"></div>',
-    '<p>Signing you in…</p>',
-    '<form method="post" action="/login/verify" id="f">',
-    `<input type="hidden" name="token" value="${safeToken}">`,
-    `<input type="hidden" name="next" value="${safeNext}">`,
-    '<noscript><button type="submit">Continue to sign in</button></noscript>',
-    '<button id="fallback" type="submit" style="display:none">Continue to sign in</button>',
-    '</form>',
-    '<script>setTimeout(function(){var f=document.getElementById("f");if(f)f.submit()},150);',
-    'setTimeout(function(){var n=document.getElementById("fallback");if(n)n.style.display="block"},3000);</script>',
-    '</div></body></html>',
-  ].join('');
-  return new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+function magicLinkConfirmPage(token: string, next: string): Response {
+  return renderConfirmPage({
+    title: 'Signing you in…',
+    bodyCopy: 'Signing you in…',
+    formAction: '/login/verify',
+    continueLabel: 'Continue to sign in',
+    hiddenFields: { token, next },
+  });
 }
 
 export async function GET(req: NextRequest) {
@@ -54,32 +26,37 @@ export async function GET(req: NextRequest) {
   const next = req.nextUrl.searchParams.get('next') || '/';
 
   if (!token) {
-    logMagicLink('warn', 'magic_link.no_token', '', { method: 'GET' });
+    log('warn', COMPONENT, 'magic_link.no_token', {
+      tokenPrefix: MISSING_TOKEN_PREFIX,
+      method: 'GET',
+    });
     return NextResponse.redirect(new URL('/login', req.url));
   }
 
   // Intentionally render the confirm page without hitting D1 — we want
   // scanner GETs to be cheap and side-effect-free. Any token validity
   // check is deferred to POST.
-  logMagicLink('info', 'magic_link.confirm_page_rendered', token.slice(0, 8));
-  return renderConfirmPage(token, next);
+  log('info', COMPONENT, 'magic_link.confirm_page_rendered', {
+    tokenPrefix: token.slice(0, 8),
+  });
+  return magicLinkConfirmPage(token, next);
 }
 
 export async function POST(req: NextRequest) {
   const formData = await req.formData();
   const token = (formData.get('token') as string | null) ?? '';
   const next = (formData.get('next') as string | null) || '/';
-  const tokenPrefix = token.slice(0, 8);
+  const tokenPrefix = token ? token.slice(0, 8) : MISSING_TOKEN_PREFIX;
 
   if (!token) {
-    logMagicLink('warn', 'magic_link.no_token', '', { method: 'POST' });
+    log('warn', COMPONENT, 'magic_link.no_token', { tokenPrefix, method: 'POST' });
     return NextResponse.redirect(new URL('/login', req.url), 303);
   }
 
   const result = await verifyMagicLink(token);
 
   if (result.success && result.sessionId) {
-    logMagicLink('info', 'magic_link.consumed', tokenPrefix);
+    log('info', COMPONENT, 'magic_link.consumed', { tokenPrefix });
     const response = NextResponse.redirect(new URL(next, req.url), 303);
     await setSessionCookie(response, result.sessionId, req.nextUrl.hostname);
     return response;
@@ -94,7 +71,7 @@ export async function POST(req: NextRequest) {
         : result.error === 'Invalid link'
           ? 'magic_link.invalid'
           : 'magic_link.failed';
-  logMagicLink('warn', errorName, tokenPrefix, { error: result.error });
+  log('warn', COMPONENT, errorName, { tokenPrefix, error: result.error });
 
   const errorUrl = new URL('/login', req.url);
   errorUrl.searchParams.set('error', result.error || 'Verification failed');

--- a/apps/lobby/lib/auth.ts
+++ b/apps/lobby/lib/auth.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { cookies } from 'next/headers';
+import type { NextResponse } from 'next/server';
 import { redirect } from 'next/navigation';
 import { getDB, getEnv } from './db';
 import { sendEmail } from './email';
@@ -89,6 +90,38 @@ export async function requireAuth(redirectTo?: string): Promise<SessionUser> {
     redirect(loginUrl);
   }
   return session;
+}
+
+// ── Session Cookie Helpers ───────────────────────────────────────────────
+
+function buildSessionCookieOptions(hostname: string) {
+  const isLocal = hostname === 'localhost' || hostname === '127.0.0.1';
+  return {
+    httpOnly: true,
+    secure: !isLocal,
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge: SESSION_EXPIRY_MS / 1000,
+    ...(isLocal ? {} : { domain: '.peckingorder.ca' }),
+  };
+}
+
+export async function setSessionCookie(
+  response: NextResponse,
+  sessionId: string,
+  hostname: string,
+): Promise<void> {
+  const cookieName = await getSessionCookieName();
+  response.cookies.set(cookieName, sessionId, buildSessionCookieOptions(hostname));
+}
+
+export async function setSessionCookieOnRequest(
+  sessionId: string,
+  hostname: string,
+): Promise<void> {
+  const cookieName = await getSessionCookieName();
+  const cookieStore = await cookies();
+  cookieStore.set(cookieName, sessionId, buildSessionCookieOptions(hostname));
 }
 
 // ── Magic Link ───────────────────────────────────────────────────────────

--- a/apps/lobby/lib/auth.ts
+++ b/apps/lobby/lib/auth.ts
@@ -94,8 +94,27 @@ export async function requireAuth(redirectTo?: string): Promise<SessionUser> {
 
 // ── Session Cookie Helpers ───────────────────────────────────────────────
 
+// Classify a request hostname as "local" for cookie-attribute purposes.
+// "Local" means: skip `secure` (HTTP is expected) and skip the production
+// `domain`. We recognise the obvious localhost pair, mDNS *.local, the
+// user's Tailscale magic DNS namespace, and RFC1918 private IPv4 ranges
+// — see reference_multi_device_dev.md for why these matter in practice:
+// mobile dev over Tailscale would otherwise silently drop the session
+// cookie (secure cookie on HTTP, wrong domain on *.ts.net).
+function isLocalHostname(hostname: string): boolean {
+  if (hostname === 'localhost' || hostname === '127.0.0.1') return true;
+  if (hostname === '::1') return true;
+  if (hostname.endsWith('.ts.net')) return true;
+  if (hostname.endsWith('.local')) return true;
+  // RFC1918 private IPv4 ranges (LAN dev hosts).
+  if (/^10\./.test(hostname)) return true;
+  if (/^192\.168\./.test(hostname)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(hostname)) return true;
+  return false;
+}
+
 function buildSessionCookieOptions(hostname: string) {
-  const isLocal = hostname === 'localhost' || hostname === '127.0.0.1';
+  const isLocal = isLocalHostname(hostname);
   return {
     httpOnly: true,
     secure: !isLocal,

--- a/apps/lobby/lib/db.ts
+++ b/apps/lobby/lib/db.ts
@@ -5,8 +5,13 @@ import { getCloudflareContext } from '@opennextjs/cloudflare';
 // D1Database type isn't available in the lobby's TS config (no @cloudflare/workers-types).
 // We type it loosely here — all D1 usage is via prepared statements which are untyped anyway.
 
+export interface D1RunResult {
+  success: boolean;
+  meta?: { changes?: number; rows_written?: number; duration?: number };
+}
+
 export interface D1PreparedResult {
-  run(): Promise<{ success: boolean }>;
+  run(): Promise<D1RunResult>;
   first<T = unknown>(): Promise<T | null>;
   all<T = unknown>(): Promise<{ results: T[] }>;
 }

--- a/apps/lobby/lib/log.ts
+++ b/apps/lobby/lib/log.ts
@@ -1,0 +1,16 @@
+// Structured log helper for lobby routes. Emits single-line JSON that
+// Workers Logs + Axiom ingest with top-level fields for easy querying.
+// Shape mirrors the `log(level, component, event, data?)` convention
+// documented in the root CLAUDE.md, adapted to Next.js on Cloudflare
+// (OpenNext) — which doesn't currently expose the game-server logger.
+
+type Level = 'info' | 'warn' | 'error';
+
+export function log(
+  level: Level,
+  component: string,
+  event: string,
+  data?: Record<string, unknown>,
+): void {
+  console.log(JSON.stringify({ level, component, event, ...(data ?? {}) }));
+}

--- a/apps/lobby/lib/log.ts
+++ b/apps/lobby/lib/log.ts
@@ -6,6 +6,12 @@
 
 type Level = 'info' | 'warn' | 'error';
 
+// The number of leading characters from a secret token to include in
+// structured logs. Enough uniqueness to join against D1.InviteTokens.token
+// (64-hex) or MagicLinks.token without writing the full secret. Callers
+// should use `token.slice(0, LOG_TOKEN_PREFIX_LEN)`.
+export const LOG_TOKEN_PREFIX_LEN = 8;
+
 export function log(
   level: Level,
   component: string,

--- a/apps/lobby/lib/render-confirm-page.ts
+++ b/apps/lobby/lib/render-confirm-page.ts
@@ -1,0 +1,65 @@
+// Shared HTML template for the GET-renders-only bot-safe confirm pages
+// used by /invite/[token] and /login/verify. Both routes need identical
+// shell (spinner, auto-submit script, 3s fallback button); only the
+// title, body copy, form action, and hidden inputs vary.
+//
+// IMPORTANT: inline <script> + <style> here depends on a permissive CSP
+// (or none). If Content-Security-Policy script-src is ever tightened on
+// the lobby, these pages break silently — auto-submit stops, users see
+// an inactive spinner until the 3s fallback button appears. Add nonces
+// at that point.
+
+export interface ConfirmPageParams {
+  title: string;
+  bodyCopy: string;
+  formAction: string;
+  continueLabel: string;
+  hiddenFields?: Record<string, string>;
+}
+
+export function renderConfirmPage(params: ConfirmPageParams): Response {
+  const { title, bodyCopy, formAction, continueLabel, hiddenFields } = params;
+  const hiddenInputs = Object.entries(hiddenFields ?? {})
+    .map(
+      ([name, value]) =>
+        `<input type="hidden" name="${encodeURIComponent(name)}" value="${encodeURIComponent(value)}">`,
+    )
+    .join('');
+  const html = [
+    '<!doctype html><html lang="en"><head>',
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width,initial-scale=1">',
+    `<title>${escapeHtml(title)}</title>`,
+    '<style>',
+    'body{margin:0;font-family:system-ui,sans-serif;background:#0f0a1a;color:#fff;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}',
+    '.card{max-width:360px;text-align:center}',
+    '.spinner{width:24px;height:24px;margin:0 auto 16px;border:2px solid #f5c842;border-top-color:transparent;border-radius:50%;animation:spin 0.8s linear infinite}',
+    'button{margin-top:16px;padding:14px 24px;background:#f5c842;color:#0f0a1a;border:0;border-radius:12px;font-weight:700;cursor:pointer;font-size:15px}',
+    '@keyframes spin{to{transform:rotate(360deg)}}',
+    '</style></head><body>',
+    '<div class="card">',
+    '<div class="spinner" aria-hidden="true"></div>',
+    `<p>${escapeHtml(bodyCopy)}</p>`,
+    `<form method="post" action="${formAction}" id="f">`,
+    hiddenInputs,
+    `<noscript><button type="submit">${escapeHtml(continueLabel)}</button></noscript>`,
+    `<button id="fallback" type="submit" style="display:none">${escapeHtml(continueLabel)}</button>`,
+    '</form>',
+    // Auto-submit after 150ms so the spinner renders first. If the POST
+    // doesn't complete within 3s, reveal a manual-continue button so the
+    // user isn't stranded on a flaky connection.
+    '<script>setTimeout(function(){var f=document.getElementById("f");if(f)f.submit()},150);',
+    'setTimeout(function(){var n=document.getElementById("fallback");if(n)n.style.display="block"},3000);</script>',
+    '</div></body></html>',
+  ].join('');
+  return new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/apps/lobby/lib/session-cookie.test.ts
+++ b/apps/lobby/lib/session-cookie.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the Cloudflare env lookup so auth.ts's getSessionCookieName uses the
+// DEFAULT_SESSION_COOKIE fallback or an override we provide per-test.
+vi.mock('./db', () => ({
+  getEnv: vi.fn(async () => ({})),
+  getDB: vi.fn(),
+}));
+
+// Stub next/headers so auth.ts imports cleanly under Node (it only uses
+// cookies() in code paths we don't exercise here).
+vi.mock('next/headers', () => ({
+  cookies: async () => ({
+    get: () => undefined,
+    set: vi.fn(),
+    delete: vi.fn(),
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+}));
+
+import { setSessionCookie } from './auth';
+import { getEnv } from './db';
+
+function fakeResponse() {
+  const set = vi.fn();
+  return {
+    response: { cookies: { set } } as any,
+    set,
+  };
+}
+
+describe('setSessionCookie', () => {
+  it('on localhost uses insecure cookie without domain', async () => {
+    const { response, set } = fakeResponse();
+    await setSessionCookie(response, 'sid-abc', 'localhost');
+    expect(set).toHaveBeenCalledTimes(1);
+    const [name, value, opts] = set.mock.calls[0];
+    expect(name).toBe('po_session');
+    expect(value).toBe('sid-abc');
+    expect(opts.secure).toBe(false);
+    expect(opts.domain).toBeUndefined();
+    expect(opts.httpOnly).toBe(true);
+    expect(opts.sameSite).toBe('lax');
+    expect(opts.path).toBe('/');
+    expect(opts.maxAge).toBe(7 * 24 * 60 * 60);
+  });
+
+  it('on 127.0.0.1 is also treated as local', async () => {
+    const { response, set } = fakeResponse();
+    await setSessionCookie(response, 'sid-abc', '127.0.0.1');
+    const [, , opts] = set.mock.calls[0];
+    expect(opts.secure).toBe(false);
+    expect(opts.domain).toBeUndefined();
+  });
+
+  it('on production hostname uses secure cookie + .peckingorder.ca domain', async () => {
+    const { response, set } = fakeResponse();
+    await setSessionCookie(response, 'sid-abc', 'lobby.peckingorder.ca');
+    const [, , opts] = set.mock.calls[0];
+    expect(opts.secure).toBe(true);
+    expect(opts.domain).toBe('.peckingorder.ca');
+    expect(opts.httpOnly).toBe(true);
+    expect(opts.sameSite).toBe('lax');
+    expect(opts.path).toBe('/');
+  });
+
+  it('on staging hostname is treated as production', async () => {
+    const { response, set } = fakeResponse();
+    await setSessionCookie(response, 'sid-abc', 'staging-lobby.peckingorder.ca');
+    const [, , opts] = set.mock.calls[0];
+    expect(opts.secure).toBe(true);
+    expect(opts.domain).toBe('.peckingorder.ca');
+  });
+
+  it('honours SESSION_COOKIE_NAME env override', async () => {
+    vi.mocked(getEnv).mockResolvedValueOnce({ SESSION_COOKIE_NAME: 'po_session_staging' });
+    const { response, set } = fakeResponse();
+    await setSessionCookie(response, 'sid-abc', 'lobby.peckingorder.ca');
+    const [name] = set.mock.calls[0];
+    expect(name).toBe('po_session_staging');
+  });
+});

--- a/apps/lobby/lib/session-cookie.test.ts
+++ b/apps/lobby/lib/session-cookie.test.ts
@@ -7,12 +7,13 @@ vi.mock('./db', () => ({
   getDB: vi.fn(),
 }));
 
-// Stub next/headers so auth.ts imports cleanly under Node (it only uses
-// cookies() in code paths we don't exercise here).
+// Shared spy for the server-action cookies() API. Individual tests can
+// reset it via cookiesSetSpy.mockClear().
+const cookiesSetSpy = vi.fn();
 vi.mock('next/headers', () => ({
   cookies: async () => ({
     get: () => undefined,
-    set: vi.fn(),
+    set: cookiesSetSpy,
     delete: vi.fn(),
   }),
 }));
@@ -21,7 +22,7 @@ vi.mock('next/navigation', () => ({
   redirect: vi.fn(),
 }));
 
-import { setSessionCookie } from './auth';
+import { setSessionCookie, setSessionCookieOnRequest } from './auth';
 import { getEnv } from './db';
 
 function fakeResponse() {
@@ -32,7 +33,14 @@ function fakeResponse() {
   };
 }
 
-describe('setSessionCookie', () => {
+const COMMON_EXPECTATIONS = (opts: any) => {
+  expect(opts.httpOnly).toBe(true);
+  expect(opts.sameSite).toBe('lax');
+  expect(opts.path).toBe('/');
+  expect(opts.maxAge).toBe(7 * 24 * 60 * 60);
+};
+
+describe('setSessionCookie (response.cookies)', () => {
   it('on localhost uses insecure cookie without domain', async () => {
     const { response, set } = fakeResponse();
     await setSessionCookie(response, 'sid-abc', 'localhost');
@@ -42,18 +50,60 @@ describe('setSessionCookie', () => {
     expect(value).toBe('sid-abc');
     expect(opts.secure).toBe(false);
     expect(opts.domain).toBeUndefined();
-    expect(opts.httpOnly).toBe(true);
-    expect(opts.sameSite).toBe('lax');
-    expect(opts.path).toBe('/');
-    expect(opts.maxAge).toBe(7 * 24 * 60 * 60);
+    COMMON_EXPECTATIONS(opts);
   });
 
-  it('on 127.0.0.1 is also treated as local', async () => {
+  it('on 127.0.0.1 and ::1 loopbacks are treated as local', async () => {
+    for (const host of ['127.0.0.1', '::1']) {
+      const { response, set } = fakeResponse();
+      await setSessionCookie(response, 'sid-abc', host);
+      const [, , opts] = set.mock.calls[0];
+      expect(opts.secure).toBe(false);
+      expect(opts.domain).toBeUndefined();
+    }
+  });
+
+  it('on Tailscale *.ts.net is treated as local', async () => {
     const { response, set } = fakeResponse();
-    await setSessionCookie(response, 'sid-abc', '127.0.0.1');
+    await setSessionCookie(response, 'sid-abc', 'manus-macbook.tail0abcd.ts.net');
     const [, , opts] = set.mock.calls[0];
     expect(opts.secure).toBe(false);
     expect(opts.domain).toBeUndefined();
+  });
+
+  it('on mDNS *.local is treated as local', async () => {
+    const { response, set } = fakeResponse();
+    await setSessionCookie(response, 'sid-abc', 'manus-macbook.local');
+    const [, , opts] = set.mock.calls[0];
+    expect(opts.secure).toBe(false);
+    expect(opts.domain).toBeUndefined();
+  });
+
+  it.each([
+    '10.0.0.4',
+    '10.255.255.255',
+    '192.168.1.20',
+    '172.16.0.1',
+    '172.31.255.1',
+  ])('on RFC1918 %s is treated as local', async (host) => {
+    const { response, set } = fakeResponse();
+    await setSessionCookie(response, 'sid-abc', host);
+    const [, , opts] = set.mock.calls[0];
+    expect(opts.secure).toBe(false);
+    expect(opts.domain).toBeUndefined();
+  });
+
+  it.each([
+    '172.15.0.1', // just outside the 172.16–31 range
+    '172.32.0.1',
+    '11.0.0.1',
+    '193.168.0.1',
+  ])('on non-RFC1918 %s is NOT treated as local', async (host) => {
+    const { response, set } = fakeResponse();
+    await setSessionCookie(response, 'sid-abc', host);
+    const [, , opts] = set.mock.calls[0];
+    expect(opts.secure).toBe(true);
+    expect(opts.domain).toBe('.peckingorder.ca');
   });
 
   it('on production hostname uses secure cookie + .peckingorder.ca domain', async () => {
@@ -62,9 +112,7 @@ describe('setSessionCookie', () => {
     const [, , opts] = set.mock.calls[0];
     expect(opts.secure).toBe(true);
     expect(opts.domain).toBe('.peckingorder.ca');
-    expect(opts.httpOnly).toBe(true);
-    expect(opts.sameSite).toBe('lax');
-    expect(opts.path).toBe('/');
+    COMMON_EXPECTATIONS(opts);
   });
 
   it('on staging hostname is treated as production', async () => {
@@ -81,5 +129,46 @@ describe('setSessionCookie', () => {
     await setSessionCookie(response, 'sid-abc', 'lobby.peckingorder.ca');
     const [name] = set.mock.calls[0];
     expect(name).toBe('po_session_staging');
+  });
+});
+
+describe('setSessionCookieOnRequest (server-action cookies())', () => {
+  it('on localhost uses insecure cookie without domain', async () => {
+    cookiesSetSpy.mockClear();
+    await setSessionCookieOnRequest('sid-abc', 'localhost');
+    expect(cookiesSetSpy).toHaveBeenCalledTimes(1);
+    const [name, value, opts] = cookiesSetSpy.mock.calls[0];
+    expect(name).toBe('po_session');
+    expect(value).toBe('sid-abc');
+    expect(opts.secure).toBe(false);
+    expect(opts.domain).toBeUndefined();
+    COMMON_EXPECTATIONS(opts);
+  });
+
+  it('on production hostname uses secure cookie + .peckingorder.ca domain', async () => {
+    cookiesSetSpy.mockClear();
+    await setSessionCookieOnRequest('sid-abc', 'lobby.peckingorder.ca');
+    const [, , opts] = cookiesSetSpy.mock.calls[0];
+    expect(opts.secure).toBe(true);
+    expect(opts.domain).toBe('.peckingorder.ca');
+    COMMON_EXPECTATIONS(opts);
+  });
+
+  it('on Tailscale hostname is treated as local (fixes claimSeat secure:true-over-HTTP bug)', async () => {
+    cookiesSetSpy.mockClear();
+    await setSessionCookieOnRequest('sid-abc', 'manus-macbook.tail0abcd.ts.net');
+    const [, , opts] = cookiesSetSpy.mock.calls[0];
+    expect(opts.secure).toBe(false);
+    expect(opts.domain).toBeUndefined();
+  });
+
+  it('mirrors setSessionCookie option matrix', async () => {
+    cookiesSetSpy.mockClear();
+    const { response, set } = fakeResponse();
+    await setSessionCookie(response, 'sid-abc', 'lobby.peckingorder.ca');
+    await setSessionCookieOnRequest('sid-abc', 'lobby.peckingorder.ca');
+    const respOpts = set.mock.calls[0][2];
+    const reqOpts = cookiesSetSpy.mock.calls[0][2];
+    expect(reqOpts).toEqual(respOpts);
   });
 });

--- a/apps/lobby/vitest.config.ts
+++ b/apps/lobby/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./', import.meta.url)),
+    },
+  },
   test: {
     environment: 'node',
     exclude: ['e2e/**', 'node_modules/**', '.vercel/**'],

--- a/docs/plans/2026-04-24-auth-flow-hardening.md
+++ b/docs/plans/2026-04-24-auth-flow-hardening.md
@@ -1,0 +1,863 @@
+# Auth Flow Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the invite/login-link friction spiral that has been eating playtest onboarding since at least Apr 5, and close the recovery gaps in the frictionless flow that bit the 2026-04-23 playtester. Deliver a lobby where a shared game URL "just works" for the dominant visitor classes — without rewriting the identity model.
+
+**Architecture:** Changes span three surfaces — lobby route handlers (`/invite/[token]`, `/login/verify`, `/j/[code]`), lobby server actions (`claimSeat`), and the client recovery cascade (`apps/client/src/App.tsx`). Most tasks are independent; Phase 1 is the highest-leverage single change and should go first.
+
+**Tech Stack:** Next.js 15 on Cloudflare via OpenNext (lobby), React 19 + Vite (client), D1 for persistence, Resend for email (no click tracking wrapping — verified).
+
+---
+
+## Context (read before starting)
+
+Evidence anchoring this plan:
+
+- **Axiom logs** (`po-logs-staging`): all `/invite/` hits across 30 days = 17 requests. Two hits from **Windows Chrome in Morganton NC + Charleston SC** (US east-coast email-security-scanner hubs) — nowhere near actual users (Vancouver / Abbotsford / Surrey). Two iOS GSA hits with `?utm_campaign=as-npt...` — a wrapper our code didn't inject, likely an iOS preview-prefetch.
+- **D1**: game `C24FZ9` (Apr 5 playtest, internal ID `game-1775416073250-898`) shows ≥8 invite tokens `used=1` with fewer enrollments — **at least 2 tokens orphaned**: `kristy@merchantsofplay.com`, `pierrebeugnot@gmail.com`. (Re-counting during 2026-04-24 review showed a count of 9 used / 8 enrolled excluding host — the exact off-by-one doesn't change the story: tokens are being consumed without enrollment at a measurable rate, numerically aligning with scanner-signature hits in Axiom.)
+- **Resend dashboard screenshot** (2026-04-23 session): most recipients who got "You've been invited" also received a "Your Pecking Order Login Link" email shortly after — the invite didn't stick, they had to magic-link recover.
+- **Resend click tracking is NOT enabled** — confirmed by the user. So the cookie-drop mechanism is not a cross-origin redirect issue; it's scanner prefetch consuming tokens before users click.
+- **Lobby HTTP log co-timing** at 21:20:07 on Apr 5 UTC: mobile user (Vancouver) hit `/invite/` at T+0, scanner (Charleston SC) hit `/invite/` at T+152ms, both followed their own redirect chains — mobile user succeeded (POST `/join/C24FZ9`), scanner bounced to `/login` (no cookie in its jar). Clean demonstration of the mechanism.
+- **Additional bugs surfaced during investigation**:
+  - `/j/[code]/actions.ts:114` sets session cookie with `secure: true` **unconditionally** (other issuance sites use `secure: !isLocal`). Triggers cookie rejection when the worker sees HTTP (CF edge isn't redirecting HTTP→HTTPS at the moment). Apr 22 A8P58R user thrashed visibly on this.
+  - `/j/[code]/page.tsx:11-43` does NOT call `getSession()` on GET — a returning-player reload shows them the welcome form again (playtest-pitfalls.md #12, still present).
+  - Client recovery cascade at `App.tsx:539` falls back to `${LOBBY_HOST}/play/CODE` when all token paths fail — that bounces to `/login` (magic-link gauntlet). For a player holding a signature-valid JWT for *any* prior game, that's recoverable identity being discarded.
+  - `startGame()` in `actions.ts:665-829` returns `tokens: Record<playerId, jwt>` for ALL players. Waiting room `waiting/page.tsx:142` uses `Object.keys(tokens)[0]` — if the host's slot isn't `p1`, they enter the client impersonating `p1`. (Playtest-pitfalls.md #8 was partially patched on `getGameSessionStatus` only; this path is still broken.)
+  - Host's "Copy Link" at `waiting/page.tsx:116` copies `/join/CODE` (auth-required) instead of `/j/CODE` (frictionless). Every stranger who taps the shared link hits the magic-link wall.
+
+### Identity model and what it enables
+
+JWTs are signed with `AUTH_SECRET` (HS256). An expired-by-time JWT is still **cryptographic proof** of `{sub, gameId, playerId, personaName}` at issue time. Current system rejects expired JWTs outright at verification. The recovery redesign in Phase 3 treats a signature-valid expired JWT as sufficient identity proof for session restoration — this is a deliberate trade-off (see "Risks & trade-offs" below).
+
+### What this plan does NOT do
+
+- Does **not** add OAuth providers (Apple/Google Sign-In). That's a separate strategic decision with larger scope; this plan preserves magic-link + frictionless and makes both more reliable. OAuth is additive later.
+- Does **not** address the anon-user cross-device recovery gap. A user who joined via `/j/CODE` without email cannot be recovered if their device is wiped — magic link has no destination. Mitigation (optional email-attach at enrollment) is flagged as follow-up, not in scope here.
+- Does **not** add in-client share UI. Covered in a separate follow-up once the canonical share URL behaves correctly.
+- Does **not** change session or JWT TTLs, secret rotation policy, or the underlying auth model. This is a reliability / recovery pass, not a redesign.
+
+---
+
+## File Structure
+
+- **`apps/lobby/app/invite/[token]/route.ts`** — split into GET (renders confirm page) + POST (consumes) — Task 1
+- **`apps/lobby/app/login/verify/route.ts`** — same split — Task 2
+- **`apps/lobby/lib/auth.ts`** — add `setSessionCookie` helpers — Task 3
+- **`apps/lobby/app/j/[code]/actions.ts`** — use centralized cookie helper — Task 4
+- **`apps/lobby/app/j/[code]/page.tsx`** — session-aware GET: short-circuit if already enrolled, redirect if authed — Task 5
+- **`apps/lobby/app/enter/[code]/route.ts`** (new) — smart-recovery endpoint accepting JWT hint — Task 6
+- **`packages/auth/src/index.ts`** — extend `verifyGameToken` with `ignoreExpiration` option — Task 6
+- **`apps/client/src/App.tsx`** — `refreshFromLobby` returns `{token, reason}`; `runAsyncRecovery` routes to `/enter/CODE` with JWT hint instead of `/play/CODE` — Task 7
+- **`apps/client/src/App.tsx`** — `LauncherScreen` empty-state shows "Sign in" CTA when no active games and no cached tokens — Task 8
+- **`apps/lobby/app/game/[id]/waiting/page.tsx`** — "Copy Link" copies `/j/CODE`; visible canonical URL — Task 9
+- **`apps/lobby/app/actions.ts`** — `startGame()` returns only caller's token (mirror `getGameSessionStatus` pattern) — Task 10
+
+---
+
+## Phase 1 — Scanner prefetch defense (P0)
+
+**Why P0**: ~90% confidence this is the dominant cause of the invite+login Resend dashboard pattern. Two tokens orphaned in the C24FZ9 dataset alone, and the fix is mechanically simple. Every day without this in prod, another playtest batch loses invitees to scanners.
+
+### Task 1: `/invite/[token]` GET-renders + POST-consumes
+
+**Why:** Corporate email security scanners (Mimecast/Proofpoint/Defender/etc.) and preview fetchers (iOS Mail preview, GSA) issue GET requests to URLs in emails with real-browser UAs. Current `route.ts:44` marks the invite token `used=1` on GET — whichever GET arrives first wins. Scanners often arrive before or concurrent with the user. The fix: render a small HTML page on GET (no token consumption), consume on POST (bots don't POST).
+
+**Files:**
+- Modify: `apps/lobby/app/invite/[token]/route.ts` (split GET/POST)
+- Verify: manual curl + D1 inspection
+
+- [ ] **Step 1: Read current route to identify the exact logic to move**
+  
+  Run: `cat apps/lobby/app/invite/[token]/route.ts`
+  Current structure: single `GET` handler that (a) looks up token, (b) handles `used`/`expired` branches, (c) marks used, (d) upserts user, (e) creates session, (f) sets cookie + 302 to `/join/CODE`.
+
+- [ ] **Step 2: Split the route into GET (validate-only, render) + POST (consume)**
+  
+  New `route.ts` shape (use a plain HTML template string, not React — route handlers don't need JSX):
+  
+  ```ts
+  import { NextRequest, NextResponse } from 'next/server';
+  import { getDB } from '@/lib/db';
+  import { generateToken, setSessionCookie } from '@/lib/auth';
+  
+  const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+  
+  type Invite = { token: string; email: string; game_id: string; invite_code: string; expires_at: number; used: number };
+  
+  async function loadInvite(token: string): Promise<Invite | null> {
+    const db = await getDB();
+    return db
+      .prepare('SELECT token, email, game_id, invite_code, expires_at, used FROM InviteTokens WHERE token = ?')
+      .bind(token)
+      .first<Invite>();
+  }
+  
+  function renderConfirmPage(token: string, inviteCode: string): Response {
+    // Plain HTML string — safe because `token` and `inviteCode` are URL-path
+    // values that we already trust (looked up in D1). inviteCode is A-Z0-9 only.
+    // token is 64-hex chars. Both are safe to embed in form action/values.
+    const html = [
+      '<!doctype html><html lang="en"><head>',
+      '<meta charset="utf-8">',
+      '<meta name="viewport" content="width=device-width,initial-scale=1">',
+      '<title>Continue to Pecking Order</title>',
+      '<style>',
+      'body{margin:0;font-family:system-ui,sans-serif;background:#0f0a1a;color:#fff;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}',
+      '.card{max-width:360px;text-align:center}',
+      '.spinner{width:24px;height:24px;margin:0 auto 16px;border:2px solid #f5c842;border-top-color:transparent;border-radius:50%;animation:spin 0.8s linear infinite}',
+      'button{margin-top:16px;padding:14px 24px;background:#f5c842;color:#0f0a1a;border:0;border-radius:12px;font-weight:700;cursor:pointer;font-size:15px}',
+      '@keyframes spin{to{transform:rotate(360deg)}}',
+      '</style></head><body>',
+      '<div class="card">',
+      '<div class="spinner" aria-hidden="true"></div>',
+      '<p>Taking you to your game…</p>',
+      `<form method="post" action="/invite/${encodeURIComponent(token)}" id="f">`,
+      '<noscript>',
+      `<button type="submit">Continue to game ${inviteCode}</button>`,
+      '</noscript>',
+      `<button id="fallback" type="submit" style="display:none">Continue to game ${inviteCode}</button>`,
+      '</form>',
+      // Auto-submit after 150ms (gives spinner time to render). If the POST
+      // doesn't complete within 3s, reveal a manual-continue button so the
+      // user isn't stuck staring at a spinner on a flaky connection.
+      '<script>setTimeout(function(){var f=document.getElementById("f");if(f)f.submit()},150);',
+      'setTimeout(function(){var n=document.getElementById("fallback");if(n)n.style.display="block"},3000);</script>',
+      '</div></body></html>',
+    ].join('');
+    return new Response(html, { headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+  }
+  
+  export async function GET(req: NextRequest, { params }: { params: Promise<{ token: string }> }) {
+    const { token } = await params;
+    const invite = await loadInvite(token);
+    const now = Date.now();
+    if (!invite) return NextResponse.redirect(new URL('/login?error=Invalid+invite+link', req.url));
+    if (invite.expires_at < now) return NextResponse.redirect(new URL('/login?error=Invite+link+expired', req.url));
+    if (invite.used) return NextResponse.redirect(new URL(`/j/${invite.invite_code}`, req.url));
+    return renderConfirmPage(token, invite.invite_code);
+  }
+  
+  export async function POST(req: NextRequest, { params }: { params: Promise<{ token: string }> }) {
+    const { token } = await params;
+    const invite = await loadInvite(token);
+    const now = Date.now();
+    if (!invite) return NextResponse.redirect(new URL('/login?error=Invalid+invite+link', req.url), 303);
+    if (invite.expires_at < now) return NextResponse.redirect(new URL('/login?error=Invite+link+expired', req.url), 303);
+    if (invite.used) return NextResponse.redirect(new URL(`/j/${invite.invite_code}`, req.url), 303);
+  
+    const db = await getDB();
+    await db.prepare('UPDATE InviteTokens SET used = 1 WHERE token = ?').bind(token).run();
+    const normalizedEmail = invite.email.toLowerCase().trim();
+    let user = await db.prepare('SELECT id FROM Users WHERE email = ?').bind(normalizedEmail).first<{ id: string }>();
+    if (!user) {
+      const userId = crypto.randomUUID();
+      await db.prepare('INSERT INTO Users (id, email, created_at) VALUES (?, ?, ?)').bind(userId, normalizedEmail, now).run();
+      user = { id: userId };
+    }
+    await db.prepare('UPDATE Users SET last_login_at = ? WHERE id = ?').bind(now, user.id).run();
+    const sessionId = generateToken();
+    await db
+      .prepare('INSERT INTO Sessions (id, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)')
+      .bind(sessionId, user.id, now + SESSION_EXPIRY_MS, now)
+      .run();
+  
+    const response = NextResponse.redirect(new URL(`/join/${invite.invite_code}`, req.url), 303);
+    await setSessionCookie(response, sessionId, req.nextUrl.hostname);
+    return response;
+  }
+  ```
+  
+  Notes: uses 303 for redirect after POST (standard "see other" for form submissions). Depends on `setSessionCookie` helper added in Task 3 — if Task 3 hasn't landed yet, inline the cookie attributes matching `login/verify/route.ts:19-25`.
+
+- [ ] **Step 3: Verify path handling and redirect semantics**
+  
+  Test manually with `curl`:
+  - `curl -i https://staging-lobby.peckingorder.ca/invite/NONEXISTENT` → 307 to `/login?error=...`
+  - `curl -i https://staging-lobby.peckingorder.ca/invite/<real-token>` → 200 HTML with form, token NOT marked used in D1 (verify with `SELECT used FROM InviteTokens WHERE token = ?`)
+  - `curl -i -X POST https://staging-lobby.peckingorder.ca/invite/<real-token>` → 303 to `/join/CODE`, Set-Cookie present, token now `used=1`
+  
+  The critical assertion: **GET does not mark the token used**.
+
+- [ ] **Step 4: Build & typecheck**
+  
+  `cd apps/lobby && npm run build`
+  Fix any TS errors around the import of `setSessionCookie` (may need to stub before Task 3 lands — in that case inline the cookie attrs temporarily).
+
+### Task 2: `/login/verify` GET-renders + POST-consumes
+
+**Why:** Same mechanism hits the magic-link path. LR8W3U Apr 23 data shows the same token hit from Surrey iOS Mobile Chrome at 00:05:47, then Vancouver iOS Mobile Chrome at 00:06:37 — 50 seconds apart, same UA family. Email preview prefetch or similar. The fix is structurally identical to Task 1.
+
+**Files:**
+- Modify: `apps/lobby/app/login/verify/route.ts`
+
+- [ ] **Step 1: Apply the same GET/POST split**
+  
+  Follow Task 1's pattern. GET validates token (look up MagicLinks row, check used/expired) + renders a confirm page with copy "Signing you in…" / button "Continue to sign in". Form POSTs back to `/login/verify` with token and `next` as hidden inputs. POST calls the existing `verifyMagicLink(token)` helper from `lib/auth.ts:146` and sets the cookie.
+  
+  For the `next` param, carry it through: `const next = req.nextUrl.searchParams.get('next') || '/'`. On POST, read from the form body: `const formData = await req.formData(); const next = (formData.get('next') as string) || '/'`.
+
+- [ ] **Step 2: Modify `renderConfirmPage` equivalent to include hidden `next` input**
+  
+  The form in the rendered HTML needs:
+  ```html
+  <form method="post" action="/login/verify" id="f">
+    <input type="hidden" name="token" value="${encodeURIComponent(token)}">
+    <input type="hidden" name="next" value="${encodeURIComponent(next)}">
+    <noscript><button type="submit">Continue to sign in</button></noscript>
+  </form>
+  ```
+
+- [ ] **Step 3: Verify the fix**
+  
+  Same curl sequence as Task 1's Step 3, adapted for the `MagicLinks` table.
+
+- [ ] **Step 4: Build**
+  
+  `cd apps/lobby && npm run build`
+
+---
+
+## Phase 2 — Frictionless flow hardening (P0)
+
+**Why P0**: `/j/CODE` is the canonical URL for shared invites post-fix (Phase 4). The current `secure:true`-on-HTTP + not-session-aware-on-GET combination means returning players and HTTP-context clicks both fail.
+
+### Task 3: Centralize session cookie helper in `lib/auth.ts`
+
+**Why:** Three files set the session cookie today (`login/verify/route.ts`, `invite/[token]/route.ts`, `j/[code]/actions.ts`) with slightly different attributes. `claimSeat` uses `secure: true` unconditionally and omits `domain`. Drift like this is what made the A8P58R Apr 22 user thrash. Centralize so there's one source of truth.
+
+**Files:**
+- Modify: `apps/lobby/lib/auth.ts`
+
+- [ ] **Step 1: Add `setSessionCookie` (for route handlers with a NextResponse) and `setSessionCookieOnRequest` (for server actions with the `cookies()` API)**
+  
+  Append to `lib/auth.ts`:
+  
+  ```ts
+  import type { NextResponse } from 'next/server';
+  
+  /**
+   * Set the session cookie on a route handler's NextResponse.
+   * Used by /invite/[token] POST and /login/verify POST.
+   */
+  export async function setSessionCookie(
+    response: NextResponse,
+    sessionId: string,
+    hostname: string,
+  ): Promise<void> {
+    const cookieName = await getSessionCookieName();
+    const isLocal = hostname === 'localhost' || hostname === '127.0.0.1';
+    response.cookies.set(cookieName, sessionId, {
+      httpOnly: true,
+      secure: !isLocal,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: SESSION_EXPIRY_MS / 1000,
+      ...(isLocal ? {} : { domain: '.peckingorder.ca' }),
+    });
+  }
+  
+  /**
+   * Set the session cookie from a server-action context (no NextResponse in hand).
+   * Used by claimSeat in /j/[code]/actions.ts.
+   */
+  export async function setSessionCookieOnRequest(
+    sessionId: string,
+    hostname: string,
+  ): Promise<void> {
+    const cookieName = await getSessionCookieName();
+    const isLocal = hostname === 'localhost' || hostname === '127.0.0.1';
+    const cookieStore = await cookies();
+    cookieStore.set(cookieName, sessionId, {
+      httpOnly: true,
+      secure: !isLocal,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: SESSION_EXPIRY_MS / 1000,
+      ...(isLocal ? {} : { domain: '.peckingorder.ca' }),
+    });
+  }
+  ```
+
+- [ ] **Step 2: Update existing issuance sites to use the helper**
+  
+  Edit `login/verify/route.ts` — replace the inline `response.cookies.set(...)` block with `await setSessionCookie(response, result.sessionId, req.nextUrl.hostname)`.
+  
+  Edit `invite/[token]/route.ts` (the POST handler from Task 1) — same replacement.
+  
+  Do NOT edit `j/[code]/actions.ts` here — Task 4 handles that.
+
+- [ ] **Step 3: Build & confirm no regression**
+  
+  `cd apps/lobby && npm run build`
+  Manual verify: `curl` a magic link, confirm Set-Cookie headers match what was being set before (httpOnly, secure on prod hostname, domain=.peckingorder.ca).
+
+### Task 4: `/j/[code]/claimSeat` uses centralized helper
+
+**Why:** Current `actions.ts:112-118` uses `secure: true` unconditionally and omits `domain`. Apr 22 A8P58R data shows a Surrey iOS user thrashed with HTTP POST requests to `/j/A8P58R` being bounced to `/login` — the `secure:true` cookie was rejected on those HTTP responses.
+
+**Files:**
+- Modify: `apps/lobby/app/j/[code]/actions.ts`
+
+- [ ] **Step 1: Import and use the async cookie helper**
+  
+  Replace `claimSeat`'s cookie-setting block (lines 110-118):
+  
+  ```ts
+  // OLD:
+  const cookieName = await getSessionCookieName();
+  const cookieStore = await cookies();
+  cookieStore.set(cookieName, sessionId, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    maxAge: SESSION_EXPIRY_MS / 1000,
+    path: '/',
+  });
+  
+  // NEW:
+  const hostname = hdrs.get('host')?.split(':')[0] || '';
+  await setSessionCookieOnRequest(sessionId, hostname);
+  ```
+  
+  Note: `hdrs` is already available from the earlier `const hdrs = await headers()` call in the rate-limit block. Reuse it. If the host header includes a port (`localhost:3000`), split on `:` to strip.
+
+- [ ] **Step 2: Build & confirm**
+  
+  `cd apps/lobby && npm run build`
+  Manual verify on staging: tap `/j/SOMECODE` over HTTPS, confirm session cookie is set and middleware sees it on the subsequent `/join/CODE` request.
+
+### Task 5: `/j/[code]/page.tsx` is session-aware on GET
+
+**Why:** Currently the page only validates the game and renders the welcome form regardless of visitor state. A returning player who reloads mid-wizard or revisits the link sees "What should we call you?" again. Worse, when Phase 3's recovery cascade redirects stale-session clients to `/j/CODE`, they need the page to route them correctly based on their state.
+
+**Files:**
+- Modify: `apps/lobby/app/j/[code]/page.tsx`
+
+- [ ] **Step 1: Add `getSession` + invites check before rendering welcome form**
+  
+  Insert after the game-status check (around line 42), before the roster fetch:
+  
+  ```tsx
+  // If visitor has a session, short-circuit based on their state in this game.
+  const session = await getSession();
+  if (session) {
+    const enrolled = await db
+      .prepare('SELECT id FROM Invites WHERE game_id = ? AND accepted_by = ?')
+      .bind(game.id, session.userId)
+      .first();
+    if (enrolled) {
+      // Already a player → drop them into /play (mints fresh JWT, launches client)
+      redirect(`/play/${code}`);
+    }
+    // Authed but not yet in this game — skip welcome, jump to persona picker.
+    redirect(`/join/${code}`);
+  }
+  // Unauth visitor: continue to welcome form (existing behavior).
+  ```
+  
+  Add `import { redirect } from 'next/navigation'` and `import { getSession } from '@/lib/auth'` at the top if missing.
+
+- [ ] **Step 2: Verify each branch**
+  
+  Manual test matrix:
+  - Anon visitor → welcome form renders (today's behavior)
+  - Authed visitor, not enrolled → redirects to `/join/CODE` (persona picker)
+  - Authed visitor, already enrolled → redirects to `/play/CODE` → client app
+  
+  For testing the authed branches, log in locally and hit `/j/<code-you-are-in>` vs `/j/<code-you-are-not-in>`.
+
+- [ ] **Step 3: Build**
+  
+  `cd apps/lobby && npm run build`
+
+**D1 read-after-write caveat**: the enrollment SELECT here reads `Invites` shortly after another path (`acceptInvite`) may have written to it. Cloudflare D1 has eventually-consistent reads across replicas — this SELECT can miss a just-committed write if it hits a lagged replica. In practice the timing window is sub-second, and the miss just means the user sees the welcome form once (the next reload works). Acceptable residual gap for this plan. If it becomes a recurring complaint, add D1 session bookmark via `db.withSession('first-primary')` on the read path. (Not implementing now — `lib/db.ts:40-43` doesn't expose session API yet; adding it is its own task.)
+
+---
+
+## Phase 3 — Recovery cascade redesign (P1)
+
+**Why P1**: The C24FZ9 playtest's users all onboarded fresh, so the recovery gap didn't dominate their experience — but the 2026-04-23 LR8W3U playtester (the one whose URL share triggered this entire investigation) hit it. Any returning player with expired session + expired cached tokens currently gets bounced to magic-link. Fix: let them re-enter using a signature-valid JWT as identity proof.
+
+### Task 6: New `/enter/[code]` route — smart recovery endpoint
+
+**Why:** The client knows when it has failed to authenticate with a game (all cached tokens missing/expired, lobby refresh returned null). Rather than redirecting to `/play/CODE` (which then bounces to `/login` → magic link), redirect to a new `/enter/CODE` that accepts a `hint` parameter containing any signature-valid JWT from the client's storage. The lobby verifies the signature, restores a session for the `sub`, and routes through enrollment or straight to play. This supports the "I played game A last month, you shared game B with me" case.
+
+**Security model**: signature-valid JWT is treated as identity proof, period. Blast radius on leak: the same as today (whoever has the JWT can already act as that user for the JWT's game). We do NOT scope-bind by URL invite code — the whole point is cross-game identity restoration. Magic link remains the path for users with no local JWT trace.
+
+**Files:**
+- Add: `apps/lobby/app/enter/[code]/route.ts`
+- Modify: `packages/auth/src/index.ts` (to support `ignoreExpiration`)
+
+- [ ] **Step 1: Extend `@pecking-order/auth` to support `ignoreExpiration`**
+  
+  `packages/auth/src/index.ts`: extend `verifyGameToken(token, secret, opts?)` where `opts.ignoreExpiration === true` catches `JWTExpired` errors and returns the decoded claims anyway. Preserve existing behavior when `opts` is omitted.
+  
+  Correct jose pattern (jose throws `JWTExpired` *after* signature verification, so the signature is already trusted when we catch):
+  
+  ```ts
+  import { jwtVerify, decodeJwt, errors } from 'jose';
+  
+  export async function verifyGameToken(
+    token: string,
+    secret: string,
+    opts?: { ignoreExpiration?: boolean },
+  ): Promise<GameTokenPayload> {
+    const key = new TextEncoder().encode(secret);
+    try {
+      const { payload } = await jwtVerify(token, key);
+      return payload as GameTokenPayload;
+    } catch (err) {
+      if (opts?.ignoreExpiration && err instanceof errors.JWTExpired) {
+        // Signature was verified before exp check; safe to decode.
+        return decodeJwt(token) as GameTokenPayload;
+      }
+      throw err;
+    }
+  }
+  ```
+  
+  Add a vitest covering: (a) valid unexpired token returns payload, (b) expired token throws without `ignoreExpiration`, (c) expired-but-signature-valid returns payload with `ignoreExpiration: true`, (d) bad-signature throws in all modes.
+
+- [ ] **Step 2: Implement the `/enter/[code]` endpoint — POST only, hint in body**
+  
+  **Security note**: a JWT in a URL param leaks to browser history, CDN access logs, Sentry breadcrumbs, and the Referer header on any subsequent request. Even "immediate redirect" doesn't protect against those retention points. Accept the hint via POST body instead. The client issues a form POST (see Task 7).
+  
+  GET on `/enter/CODE` with no hint renders a tiny auto-submitting recovery page that POSTs back (analogous to Task 1's confirm page shape) — handles the case where someone lands at `/enter/CODE` directly (bookmark, bad redirect). That GET with no hint just routes to `/j/CODE`. The real work is POST:
+  
+  ```ts
+  import { NextRequest, NextResponse } from 'next/server';
+  import { getDB, getEnv } from '@/lib/db';
+  import { getSession, generateToken, setSessionCookie } from '@/lib/auth';
+  import { verifyGameToken } from '@pecking-order/auth';
+  
+  const SESSION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+  
+  // GET with no hint → just route to /j/CODE welcome (handles bookmarks / odd arrivals)
+  export async function GET(req: NextRequest, { params }: { params: Promise<{ code: string }> }) {
+    const { code } = await params;
+    const session = await getSession();
+    if (session) return NextResponse.redirect(new URL(`/play/${code}`, req.url));
+    return NextResponse.redirect(new URL(`/j/${code}`, req.url));
+  }
+  
+  export async function POST(req: NextRequest, { params }: { params: Promise<{ code: string }> }) {
+    const { code } = await params;
+    const formData = await req.formData();
+    const hint = formData.get('hint') as string | null;
+    const db = await getDB();
+    const env = await getEnv();
+    const AUTH_SECRET = (env.AUTH_SECRET as string) || 'dev-secret-change-me';
+  
+    const session = await getSession();
+    if (session) return NextResponse.redirect(new URL(`/play/${code}`, req.url), 303);
+  
+    const game = await db
+      .prepare('SELECT id, status FROM GameSessions WHERE invite_code = ?')
+      .bind(code.toUpperCase())
+      .first<{ id: string; status: string }>();
+    if (!game) return NextResponse.redirect(new URL('/login?error=Game+not+found', req.url), 303);
+  
+    if (hint) {
+      try {
+        const decoded = await verifyGameToken(hint, AUTH_SECRET, { ignoreExpiration: true });
+        const user = await db
+          .prepare('SELECT id FROM Users WHERE id = ?')
+          .bind(decoded.sub)
+          .first<{ id: string }>();
+        if (user) {
+          const sessionId = generateToken();
+          const now = Date.now();
+          await db
+            .prepare('INSERT INTO Sessions (id, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)')
+            .bind(sessionId, user.id, now + SESSION_EXPIRY_MS, now)
+            .run();
+          await db.prepare('UPDATE Users SET last_login_at = ? WHERE id = ?').bind(now, user.id).run();
+          const response = NextResponse.redirect(new URL(`/play/${code}`, req.url), 303);
+          await setSessionCookie(response, sessionId, req.nextUrl.hostname);
+          return response;
+        }
+      } catch {
+        // Invalid hint (signature mismatch, malformed) — fall through to welcome.
+      }
+    }
+  
+    return NextResponse.redirect(new URL(`/j/${code}`, req.url), 303);
+  }
+  ```
+
+- [ ] **Step 3: Test the endpoint**
+  
+  Manual test on local dev:
+  - `curl -i http://localhost:3000/enter/NONEXISTENT` (GET) → 307 to `/j/NONEXISTENT`
+  - `curl -i -X POST http://localhost:3000/enter/NONEXISTENT` (POST, no form body) → 303 to `/login?error=Game+not+found`
+  - `curl -i -X POST -d "hint=" http://localhost:3000/enter/VALIDCODE` (empty hint) → 303 to `/j/VALIDCODE`
+  - `curl -i -X POST -d "hint=<signature-valid-expired-JWT-for-sub-X>" http://localhost:3000/enter/VALIDCODE` where X exists in Users → 303 to `/play/VALIDCODE`, session cookie set
+  - `curl -i -X POST -d "hint=garbage" http://localhost:3000/enter/VALIDCODE` → 303 to `/j/VALIDCODE`
+  - **Authed viewer NOT a player in this game** (valid session cookie for user X, X has no Invites row for VALIDCODE): GET `/enter/VALIDCODE` → 307 to `/play/VALIDCODE` → `/play` returns its existing 403 response. Unchanged behavior inherited from `/play/CODE`; noted here so future readers don't expect `/enter/CODE` to handle non-participation specially.
+
+### Task 7: Client recovery cascade routes to `/enter/CODE` with JWT hint
+
+**Why:** Today `runAsyncRecovery` at `App.tsx:503-546` ends with `window.location.href = LOBBY_HOST/play/CODE` when all local token paths fail — which bounces to magic-link. Replace with a redirect to `/enter/CODE?hint=<any-JWT-we-have>`. The hint gives the lobby enough to restore identity without requiring magic-link.
+
+**Files:**
+- Modify: `apps/client/src/App.tsx`
+
+- [ ] **Step 1: Extend `refreshFromLobby` to return reason alongside token**
+  
+  `App.tsx:206-222`:
+  
+  ```ts
+  async function refreshFromLobby(gameCode: string): Promise<{ token: string | null; reason?: string }> {
+    try {
+      const res = await fetch(`${LOBBY_HOST}/api/refresh-token/${gameCode}`, { credentials: 'include' });
+      if (!res.ok) {
+        console.warn('[App] refreshFromLobby: lobby returned', res.status, 'for', gameCode);
+        return { token: null, reason: `http_${res.status}` };
+      }
+      const { token, reason } = await res.json();
+      return { token: token ?? null, reason };
+    } catch (err) {
+      console.warn('[App] Lobby token refresh failed:', err);
+      return { token: null, reason: 'network_error' };
+    }
+  }
+  ```
+  
+  Update the call site in `runAsyncRecovery` accordingly (destructure `token, reason`).
+
+- [ ] **Step 2: Add `findAnyJwtHint` helper**
+  
+  After the existing token-recovery helpers, add:
+  
+  ```ts
+  /** Return any locally-cached JWT to use as an identity hint when recovery fails.
+   *  Prefers the most recently-issued (highest iat). Returns null if nothing is
+   *  stored — the caller should then route the visitor through the frictionless
+   *  welcome instead of attempting identity restoration. */
+  function findAnyJwtHint(): string | null {
+    let best: { jwt: string; iat: number } | null = null;
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key?.startsWith('po_token_')) continue;
+      const jwt = localStorage.getItem(key);
+      if (!jwt) continue;
+      try {
+        const decoded = decodeGameToken(jwt);
+        const iat = decoded.iat ?? 0;
+        if (!best || iat > best.iat) best = { jwt, iat };
+      } catch {
+        // Malformed — skip.
+      }
+    }
+    if (best) return best.jwt;
+    // Fallback: scan po_pwa_* cookies
+    const matches = document.cookie.matchAll(/po_pwa_([^=]+)=([^;]+)/g);
+    for (const m of matches) {
+      try {
+        const jwt = m[2];
+        decodeGameToken(jwt); // parseable check
+        return jwt;
+      } catch {
+        // skip
+      }
+    }
+    return null;
+  }
+  ```
+
+- [ ] **Step 3: Rewrite `runAsyncRecovery` final-step fallback**
+  
+  Replace `App.tsx:536-539` (the "Step 4: Redirect to lobby" block). **Use a form POST, not a URL param**, so the JWT hint never appears in browser history / CDN access logs / Referer headers:
+  
+  ```ts
+  // Step 4: Recovery fallback — hand off to lobby's /enter/CODE with any
+  // JWT we can find as identity hint. Submit via form POST so the JWT
+  // doesn't leak into URL params, browser history, or access logs.
+  // Lobby decides: restore identity → /play/CODE, or drop to /j/CODE welcome.
+  const hint = findAnyJwtHint();
+  console.log('[App] recovery step 4: redirecting to /enter/', code, hint ? '(with JWT hint)' : '(no hint)');
+  setSentryAuthMethod('lobby-recover');
+  if (hint) {
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = `${LOBBY_HOST}/enter/${code}`;
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'hint';
+    input.value = hint;
+    form.appendChild(input);
+    document.body.appendChild(form);
+    form.submit();
+  } else {
+    window.location.href = `${LOBBY_HOST}/j/${code}`;
+  }
+  ```
+
+- [ ] **Step 4: Typecheck & manual smoke test**
+  
+  `cd apps/client && npm run build`
+  Run locally: clear all storage, hit `http://localhost:5173/game/TESTCODE`. Confirm recovery lands on `/j/TESTCODE` (no hint available) rather than `/play/TESTCODE` → login. Then set a `po_token_OLDGAME` in localStorage (pick an expired but signature-valid JWT) and hit `/game/NEWCODE` — confirm redirect to `/enter/NEWCODE?hint=...` and then `/play/NEWCODE`.
+
+### Task 8: `LauncherScreen` empty state surfaces "Sign in" CTA
+
+**Why:** The DOUBLE-EXPIRED case (no session, no tokens anywhere) reaches the launcher via `runAsyncRecovery` or direct PWA launch. Current empty state shows "Have an invite code?" form only — no path for a returning player whose device fully expired. Add a visible "Sign in with email" link that goes to `${LOBBY_HOST}/login`.
+
+**Files:**
+- Modify: `apps/client/src/App.tsx` (the `LauncherScreen` component around line 604+)
+
+- [ ] **Step 1: Add a "Sign in" link under the code-entry form when empty**
+  
+  Inside `LauncherScreen`, after the code entry form and ONLY when `cachedGames.length === 0`, add:
+  
+  ```tsx
+  <div className="mt-6 text-center text-xs text-skin-dim">
+    <p className="mb-2">Played before?</p>
+    <a
+      href={`${LOBBY_HOST}/login`}
+      className="inline-block px-4 py-2 rounded-lg border border-skin-base/30 text-skin-base hover:border-skin-gold/50"
+    >
+      Sign in with email
+    </a>
+  </div>
+  ```
+
+- [ ] **Step 2: Verify**
+  
+  Clear browser storage, load the client's root URL. Confirm sign-in link appears. Click it — confirm it navigates to lobby `/login`.
+
+---
+
+## Phase 4 — Canonical share URL (P1)
+
+**Why P1**: The host's "Copy Link" button today shares `/join/CODE` which requires login. Changing it to `/j/CODE` means strangers who tap shared links hit the frictionless welcome. High-leverage single-line change + small supporting UX.
+
+**`/join/CODE` emitter audit (verified 2026-04-24)**:
+- `apps/lobby/app/game/[id]/waiting/page.tsx:116` — host Copy Link — **fix in Step 1 below**.
+- `apps/lobby/app/invite/[token]/route.ts:34` — already-used branch bounces unauth user to `/join/CODE` — **already rerouted to `/j/CODE` by Task 1**.
+- `apps/lobby/app/invite/[token]/route.ts:74` — POST-success redirect — stays `/join/CODE` (user is authenticated at that point, cookie just set; middleware won't bounce). No change needed.
+- `apps/lobby/app/page.tsx:1271` — host-home "Join as Host" link — host is authed, safe. Consider renaming for clarity in a later pass; not in scope here.
+- Email templates (`apps/lobby/lib/email-templates.ts`) and `apps/nudge-worker/` emit no `/join/` URLs directly — invite emails contain `/invite/TOKEN` which resolves internally.
+
+Audit result: no additional emitters need to change as part of this phase.
+
+### Task 9: Host waiting room "Copy Link" → `/j/CODE` + visible canonical URL
+
+**Files:**
+- Modify: `apps/lobby/app/game/[id]/waiting/page.tsx`
+
+- [ ] **Step 1: Change `handleCopyLink`**
+  
+  `waiting/page.tsx:116`:
+  
+  ```ts
+  // OLD:
+  const link = `${window.location.origin}/join/${code.toUpperCase()}`;
+  // NEW:
+  const link = `${window.location.origin}/j/${code.toUpperCase()}`;
+  ```
+
+- [ ] **Step 2: Surface the full URL in the UI**
+  
+  In the header area near the invite code display, replace the bare code block with:
+  
+  ```tsx
+  <div className="space-y-2 mt-2">
+    <div className="text-[10px] font-bold text-skin-dim uppercase tracking-widest">Invite link</div>
+    <div className="flex items-center gap-2 p-2.5 rounded-lg bg-skin-input/60">
+      <code className="flex-1 text-xs font-mono text-skin-base truncate">
+        {typeof window !== 'undefined' ? `${window.location.origin}/j/${code.toUpperCase()}` : ''}
+      </code>
+      <button onClick={handleCopyLink} className="text-xs font-bold text-skin-gold px-2 py-1 rounded border border-skin-gold/30">
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+    </div>
+  </div>
+  ```
+  
+  Lets hosts see *what they're sharing* before tapping Copy, preventing them from reconstructing URLs by hand.
+
+- [ ] **Step 3: Verify**
+  
+  Create a test game locally, open waiting room, click Copy. Paste into a new browser window, confirm `/j/CODE` loads the welcome form (not `/login`).
+
+---
+
+## Phase 5 — Host impersonation fix (P1)
+
+**Why P1**: Documented in `docs/runbooks/playtest-pitfalls.md` #8, partially patched on `getGameSessionStatus` but `startGame()` still returns all players' tokens. A host in any slot other than `p1` who clicks "Launch Game" enters the client as `p1`.
+
+### Task 10: `startGame()` returns only the caller's token
+
+**Files:**
+- Modify: `apps/lobby/app/actions.ts` (the `startGame` function around line 665-829)
+
+**Reachability confirmed (2026-04-24 grep)**: `startGame` is still called at `apps/lobby/app/game/[id]/waiting/page.tsx:77`. The earlier "revert of the Start Game button" (commit 9187fe4) was a different, host-facing button on `/game/CODE/waiting` for CC games — the Launch Game button for STATIC games still calls `startGame()`. Task 10 is NOT dead code; the host-impersonation bug is reachable in production.
+
+- [ ] **Step 1: Confirm game-server `/init` contract**
+  
+  Read `apps/game-server/src/http-handlers.ts` `/init` route. Look for any dependency on an incoming `tokens` field. Expected: `/init` takes roster only; tokens are for client-side use, not forwarded to game-server. If `tokens` is forwarded to game-server, flag as a follow-up — but this task is safe to do either way because the caller doesn't NEED all tokens.
+
+- [ ] **Step 2: Move token minting outside the all-players roster loop**
+  
+  Currently `actions.ts:728-758` mints a JWT per-player inside the roster loop and stuffs every one into `tokens`. Change to:
+  
+  ```ts
+  // Build roster (no tokens in the loop)
+  const roster: Roster = {};
+  for (let i = 0; i < invites.length; i++) {
+    const inv = invites[i];
+    const pid = `p${i + 1}`;
+    roster[pid] = {
+      realUserId: inv.accepted_by,
+      personaName: inv.persona_name,
+      avatarUrl: personaImageUrl(inv.persona_id, 'headshot', env.PERSONA_ASSETS_URL as string),
+      bio: inv.custom_bio || inv.persona_description,
+      qaAnswers: inv.qa_answers ? JSON.parse(inv.qa_answers) : undefined,
+      isAlive: true,
+      isSpectator: false,
+      silver: 50,
+      gold: 0,
+      destinyId: 'FLOAT',
+    };
+  }
+  
+  // Mint token ONLY for the calling user, mirroring getGameSessionStatus's pattern.
+  const myInviteIndex = invites.findIndex((i) => i.accepted_by === session.userId);
+  let tokens: Record<string, string> | undefined;
+  if (myInviteIndex >= 0) {
+    const myPid = `p${myInviteIndex + 1}`;
+    const myInvite = invites[myInviteIndex];
+    const tokenExpiry = `${game.day_count * 2 + 7}d`;
+    tokens = {
+      [myPid]: await signGameToken(
+        { sub: session.userId, gameId: game.id, playerId: myPid, personaName: myInvite.persona_name },
+        AUTH_SECRET,
+        tokenExpiry,
+      ),
+    };
+  }
+  ```
+
+- [ ] **Step 3: Verify host-impersonation is closed**
+  
+  Locally: create a game, have two users accept (arrange for the host to be p2, not p1). Click Launch from the host's window. Confirm waiting-page's `Object.keys(tokens)[0]` is `p2` (the host's actual slot), not `p1`. Confirm client `_t=` query param decodes to `playerId: 'p2'`.
+
+---
+
+## Phase 6 — Edge hardening (P2, deferrable)
+
+### Task 11: Enable Cloudflare "Always Use HTTPS" on lobby and api domains
+
+**Why (confirmed 2026-04-24)**: `curl -i http://staging-lobby.peckingorder.ca/` returns 307 redirect that STAYS on HTTP (goes to `http://staging-lobby.peckingorder.ca/login?next=%2F`). HTTP requests reach the worker. The `staging-play.peckingorder.ca` domain correctly returns 301→https — so the zone-level setting is partial, not global.
+
+- [ ] **Step 1: Dashboard configuration**
+  
+  Cloudflare Dashboard → SSL/TLS → Edge Certificates → Always Use HTTPS: ON. Likely needs to be enabled per-subdomain or via a Page Rule — check why the `play` subdomain already redirects while `lobby` doesn't (could be a Page Rule, different zone, or explicit override). Match the `play` config for `lobby`, `api`, and any other missing subdomains.
+
+- [ ] **Step 2: Verify via curl**
+  
+  After enabling: `curl -sI http://staging-lobby.peckingorder.ca/` should return `301` with `location: https://...`. Confirm for `lobby`, `api`, all playtest subdomains.
+
+### Task 12: Add structured logging to `/invite/[token]` and `/login/verify`
+
+**Why:** Current routes are silent on failure branches. Future investigations need at-a-glance visibility.
+
+- [ ] **Step 1: Log at each branch**
+
+  Use `console.log(JSON.stringify({ level, component, event, data }))` for each:
+  - `invite.invalid` — token not found
+  - `invite.expired` — token expired
+  - `invite.already_used` — if the bot-prefetch pattern recurs, include `ageSinceCreatedMs` in data
+  - `invite.consumed` — successful POST, include `emailHash` (not email) for tracing
+  - Mirror for `/login/verify`.
+
+---
+
+## Verification strategy
+
+**Unit / integration tests** (required — auth-flow regression risk is real):
+
+Add vitest coverage, aiming for ~30 minutes of test work to lock in the fixes:
+
+1. **`packages/auth/__tests__/verifyGameToken.test.ts`** — table-driven:
+   - Valid unexpired token → returns payload.
+   - Expired token, `ignoreExpiration` omitted → throws `JWTExpired`.
+   - Expired token, `ignoreExpiration: true` → returns payload.
+   - Bad-signature token → throws regardless of `ignoreExpiration`.
+   - Malformed token → throws regardless of `ignoreExpiration`.
+
+2. **`apps/lobby/__tests__/invite-route.test.ts`** — mock D1:
+   - GET with unknown token → 307 to `/login?error=Invalid+invite+link`, token untouched.
+   - GET with expired token → 307 to `/login?error=Invite+link+expired`, token untouched.
+   - GET with already-used token → 307 to `/j/CODE`, token unchanged (`used=1`).
+   - GET with valid-unused token → 200 HTML, token STILL `used=0` (the critical assertion — GET must not consume).
+   - POST with valid-unused token → 303 to `/join/CODE`, token `used=1`, Set-Cookie header present.
+   - POST called twice in rapid succession → second hits `if (used)` branch, returns 303 without double-creating session.
+
+3. **`apps/lobby/__tests__/setSessionCookie.test.ts`** — cookie-attribute helper:
+   - Localhost hostname → no `secure`, no `domain`.
+   - Production hostname → `secure: true`, `domain: .peckingorder.ca`.
+   - Cookie name matches `SESSION_COOKIE_NAME` env var (fallback to `po_session`).
+   - All attributes (`httpOnly`, `sameSite=lax`, `path=/`, `maxAge`) present in both modes.
+
+**Manual curl / browser**: each task includes explicit test-case steps with D1 state assertions.
+
+**End-to-end playtest**: After Phases 1-3 ship, run a staged playtest using the `playtest-sim` skill with 4-6 simulated invitees. Measure:
+- % of invites consumed via `/invite/POST` vs. stuck on `used=1` (target: ~0% stuck unless token truly expired)
+- % of recipients who also receive a `/login/verify` email after (target: < 20%, down from the ~80% we've been observing)
+- Any `/login?error=Link+already+used` hits in lobby logs (target: 0)
+
+**Post-deploy monitoring (first week)**:
+- Resend dashboard: watch the ratio of "You've been invited" to "Your Pecking Order Login Link" emails per user. Pre-fix ratio: ~1:1. Target: > 5:1.
+- Axiom query for `/invite/` POST vs GET volume ratio. Healthy: most consumes are POSTs. Unhealthy: GETs still marking used (regression).
+
+**Concrete revert triggers** (if any fires within 48h of deploy, roll back the responsible phase):
+- `/login?error=Link+already+used` hits in lobby Axiom logs > 2/day — Phase 1 regression (Task 1 or Task 2).
+- `/enter/CODE` POST → `/login?error=...` rate > 10% of all POSTs — Phase 3 regression (Task 6).
+- Sentry reports of "stuck on spinner" from Task 1's confirm page (visible via session replays) — Phase 1 auto-submit regression; revisit the 150ms/3s timing.
+- D1 writes to `Sessions` spike without corresponding `/invite/POST` or `/login/verify POST` — something else is minting sessions (should not happen).
+
+**Migration note for in-flight invite emails**: invite emails delivered BEFORE Phase 1 ships contain URLs to a GET-consumes handler. After Phase 1 deploys, those same URLs hit the new GET-renders-page handler — the recipient sees the confirmation page instead of a direct redirect. Auto-submit handles this transparently for JS-enabled browsers (all real users). Pre-existing emails stay functional; no user-visible disruption.
+
+If an email was pre-fetched by a scanner BEFORE Phase 1 ships, its token is already `used=1` and the user will still bounce to `/j/CODE` (via Task 1's `if (used)` branch) on their click. That's no worse than today's behavior. They can be re-invited by the host via the waiting-room email form — which now also benefits from the POST-consumes pattern.
+
+---
+
+## Risks & trade-offs
+
+**Expired-JWT-as-identity** (Task 6): A leaked JWT remains valid identity proof indefinitely (until `AUTH_SECRET` rotates). For a low-stakes social game between friends this is an acceptable trade for friction reduction. Mitigations:
+- Optional follow-up: cap acceptance window (e.g., refuse hints where `now - exp > 90 days`). Not implemented initially; revisit if abuse surfaces.
+- `AUTH_SECRET` rotation kills all historical JWTs → emergency revocation path.
+
+**Auto-submit JS bypass** (Tasks 1, 2): Sophisticated scanners could start executing JS to defeat the POST barrier. Not a current threat in the wild (scanners today are GET-only). If/when scanners evolve, fallback is CAPTCHA or server-side bot-challenge — out of scope now.
+
+**`/enter/CODE` hint delivery** (Task 6): hint is delivered via POST form body, not URL query. Browser history, CDN access logs, Sentry breadcrumbs, and Referer headers do not retain the JWT. This is a deliberate security property of the Task 6 / Task 7 design, not a mitigation — URL-param hint passing was considered and rejected.
+
+**Existing in-flight games' tokens**: None of these changes invalidate existing JWTs. Users with live sessions stay authenticated.
+
+---
+
+## Open questions (deferred, not blocking this plan)
+
+1. **OAuth providers** (Apple Sign-In, Google Sign-In): strategic question for the audience (teens). Should be evaluated separately once magic-link + frictionless is reliable.
+2. **Anon user cross-device recovery**: a user who joined via `/j/CODE` without email cannot currently be recovered if their device is wiped. Mitigation: optional email-attach at enrollment time. Surface as follow-up.
+3. **Capping expired-JWT acceptance window**: see Risks above. Revisit if/when first abuse case surfaces.
+4. **In-client share UI**: separate feature. Once canonical share URL (Phase 4) is stable, adding a share button inside the client is ~50 lines.
+5. **`/play/CODE` non-participant 403 page**: currently returns bare text. Low priority cosmetic; separate cleanup.
+
+---
+
+## Sequencing recommendation
+
+**Ship Phases 1 & 2 together in one PR** — they're the highest-value fixes and are all route-handler / action changes, low risk, easy to review. Run a smoke-test playtest before moving on.
+
+**Phase 3 depends on the `@pecking-order/auth` package change** (ignoreExpiration) — package bump required. Slightly heavier PR, but self-contained.
+
+**Phases 4-5** are independent cleanups; can go in parallel or after.
+
+**Phase 6** is deferrable. Do when you have a quiet moment.
+
+---
+
+**Total scope estimate**: 4-6 hours for an engineer to implement Phases 1-3 cleanly, plus a playtest-sim round to verify. Phases 4-5 add another 1-2 hours. Plan is aggressive but has clear natural break-points.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -35,9 +35,11 @@ export async function verifyGameToken(
     return payload as unknown as GameTokenPayload;
   } catch (err) {
     // jose verifies the signature BEFORE the exp claim, so a JWTExpired
-    // error means the signature was trusted. Safe to decode and return
-    // when the caller opts in — used by /enter/CODE recovery to accept
-    // expired-but-still-authentic identity proofs.
+    // error means the signature is trusted. We deliberately narrow to
+    // JWTExpired only — other JWTClaimValidationFailed subclasses (nbf,
+    // iss, aud) are still rejected even with ignoreExpiration: true.
+    // If future callers need a broader trust surface, add opts.flags
+    // rather than loosening this branch.
     if (opts?.ignoreExpiration && err instanceof joseErrors.JWTExpired) {
       return decodeJwt(token) as unknown as GameTokenPayload;
     }

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,4 +1,4 @@
-import { SignJWT, jwtVerify, decodeJwt } from 'jose';
+import { SignJWT, jwtVerify, decodeJwt, errors as joseErrors } from 'jose';
 
 // ── Game Token (lobby → client → game server) ──────────────────────────
 
@@ -27,10 +27,22 @@ export async function signGameToken(
 export async function verifyGameToken(
   token: string,
   secret: string,
+  opts?: { ignoreExpiration?: boolean },
 ): Promise<GameTokenPayload> {
   const key = new TextEncoder().encode(secret);
-  const { payload } = await jwtVerify(token, key);
-  return payload as unknown as GameTokenPayload;
+  try {
+    const { payload } = await jwtVerify(token, key);
+    return payload as unknown as GameTokenPayload;
+  } catch (err) {
+    // jose verifies the signature BEFORE the exp claim, so a JWTExpired
+    // error means the signature was trusted. Safe to decode and return
+    // when the caller opts in — used by /enter/CODE recovery to accept
+    // expired-but-still-authentic identity proofs.
+    if (opts?.ignoreExpiration && err instanceof joseErrors.JWTExpired) {
+      return decodeJwt(token) as unknown as GameTokenPayload;
+    }
+    throw err;
+  }
 }
 
 /** Client-side decode (no verification — for display only) */


### PR DESCRIPTION
## Summary

Implements all actionable phases of [docs/plans/2026-04-24-auth-flow-hardening.md](../blob/main/docs/plans/2026-04-24-auth-flow-hardening.md). Addresses the invite+login-link friction spiral observed across playtests (C24FZ9 Apr 5, LR8W3U Apr 23, A8P58R Apr 22) and verified via Axiom + D1 + Resend dashboard.

### Phase 1 — Scanner-prefetch defense (P0)

Email-security scanners (Mimecast / Proofpoint / iOS preview) were GET-prefetching `/invite/TOKEN` and `/login/verify?token=` URLs in delivered emails, consuming tokens before the real user could click. 2+ tokens orphaned in C24FZ9 alone, matching east-coast scanner hits in Axiom.

- **`/invite/[token]`**: split GET (renders auto-submitting confirm page, no D1 writes) + POST (consumes token, upserts user, mints session).
- **`/login/verify`**: same GET-renders / POST-consumes split, carries `next` as hidden form input.

### Phase 2 — Frictionless flow hardening (P0)

- **`lib/auth.ts`**: new `setSessionCookie` + `setSessionCookieOnRequest` helpers — single source of truth for cookie attrs, adapts `secure` to hostname.
- **`j/[code]/actions.ts` (claimSeat)**: uses the helper (fixes unconditional `secure:true` on HTTP that thrashed Surrey iOS in A8P58R).
- **`j/[code]/page.tsx`**: session-aware GET. Anon or enrolled-pre-start → welcome view (joined cast + social context). Authed+unenrolled → `/join/CODE`. Authed+enrolled+STARTED → `/play/CODE`.

### Phase 3 — Recovery cascade (P1)

- **`packages/auth`**: `verifyGameToken` gains `ignoreExpiration`. Jose verifies signature before exp claim, so expired-but-authentic tokens can be accepted as identity proof. Bad signatures still throw.
- **`/enter/[code]` (new)**: GET routes by session; POST accepts `hint=<jwt>` form body, restores a session for `sub` on valid signature, redirects to `/play/CODE` (or falls through to `/j/CODE` on any failure). Hint is POST-only — never lands in URL params, history, or Referer.
- **`apps/client/App.tsx`**:
  - `refreshFromLobby` returns `{token, reason}` for Sentry tracing.
  - New `findAnyJwtHint` picks the freshest cached JWT.
  - Recovery step 4 now POSTs to `/enter/CODE` with hint (or plain `/j/CODE` if nothing cached), replacing the old `/play/CODE` fallback that bounced to the magic-link wall.
  - `LauncherScreen` empty state now shows a "Sign in with email" CTA.

### Phase 4 — Canonical share URL (P1)

- **`waiting/page.tsx`**: Copy Link now copies `/j/CODE` (frictionless welcome) instead of `/join/CODE` (auth-walled). Full URL is visible above the button so hosts see what they're sharing.

### Phase 5 — Host impersonation fix (P1)

- **`startGame`**: token minting moved out of the roster loop; only the calling user's JWT is returned. Closes playtest-pitfalls.md #8 where `Object.keys(tokens)[0]` put any non-p1 host into the client impersonating p1.

### Phase 6 — Edge hardening (P2, partial)

- Structured JSON logs added to `/invite` and `/login/verify` at every branch. `tokenPrefix` (8 chars) joins to D1 without writing full secrets to Axiom.
- **Not included**: Cloudflare "Always Use HTTPS" toggle (Phase 6 Task 11). Dashboard setting, requires your access — see post-merge steps below.

## Test coverage

- `packages/auth` verifyGameToken: 6 cases (valid / expired both modes / bad sig / malformed / expired+bad-sig) via `apps/lobby/__tests__/verifyGameToken.test.ts`
- `lib/session-cookie.test.ts`: 5 cases (localhost / 127.0.0.1 / prod / staging / env override)
- `__tests__/invite-route.test.ts`: 9 cases (GET branches never consume; POST + idempotency)
- Full suites: **lobby 34/34, client 143/143**, both builds green.

## Live-staging verification (from the Phase 1+2 commit)

End-to-end against `staging-lobby.peckingorder.ca` with a real unused invite token in D1:
- GET valid-unused token → 200 HTML confirm page, D1 `used` still `0` ← **the core fix**
- POST → 303 `/join/CODE` + `Set-Cookie: po_session_stg=…; Domain=.peckingorder.ca; Secure; HttpOnly; SameSite=lax`, D1 `used=1`
- POST twice → second idempotent, session count stays 1
- GET a now-used token → 307 `/j/CODE`

## Post-merge steps

1. **Enable Cloudflare "Always Use HTTPS"** on `lobby.peckingorder.ca`, `api.peckingorder.ca`, and staging equivalents. Dashboard → SSL/TLS → Edge Certificates. The `play` subdomain already redirects; match that config across the others. Verify via: `curl -sI http://staging-lobby.peckingorder.ca/` should return `301` with `location: https://...`.
2. **Resend dashboard watch (48h)**: invite:login-link email ratio. Pre-fix ~1:1; target > 5:1.
3. **Axiom watch**: `/invite/*` POST vs GET ratio (healthy = most consumes are POSTs).

## Revert triggers (from the plan)

- `/login?error=Link+already+used` > 2/day → Phase 1 regression.
- `/enter/CODE` POST → `/login?error=...` > 10% of POSTs → Phase 3 regression.
- Session-insert spike without matching POST logs → something is minting sessions unexpectedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)