### PR TITLE
feat(pulse): cast-strip share chip during pregame

### DIFF
--- a/apps/client/src/hooks/useGameEngine.ts
+++ b/apps/client/src/hooks/useGameEngine.ts
@@ -40,8 +40,16 @@ export const useGameEngine = (gameId: string, playerId: string, token?: string |
     console.warn('[WS] Connecting without token — using playerId fallback (debug mode)');
   }
 
+  // Derive ws/wss from VITE_GAME_SERVER_HOST's scheme. PartySocket defaults
+  // to wss for any non-localhost host, which silently breaks Tailscale-style
+  // dev where the page is served from a real hostname over plain HTTP and
+  // the game server is also plain HTTP. Production (https://api.…) → wss.
+  const gsUrl = new URL(import.meta.env.VITE_GAME_SERVER_HOST || "http://localhost:8787");
+  const wsProtocol: 'ws' | 'wss' = gsUrl.protocol === 'https:' ? 'wss' : 'ws';
+
   const socket = usePartySocket({
-    host: new URL(import.meta.env.VITE_GAME_SERVER_HOST || "http://localhost:8787").host,
+    host: gsUrl.host,
+    protocol: wsProtocol,
     room: gameId,
     party,
     query,

--- a/apps/client/src/shells/pulse/components/caststrip/CastStrip.tsx
+++ b/apps/client/src/shells/pulse/components/caststrip/CastStrip.tsx
@@ -5,7 +5,17 @@ import { useHasOverflow } from '../../hooks/useHasOverflow';
 import { PULSE_Z } from '../../zIndex';
 import { CastChip } from './CastChip';
 import { GroupChip } from './GroupChip';
+import { ShareChip } from './ShareChip';
 import { DayPhases } from '@pecking-order/shared-types';
+
+/** Pull the invite code from the client URL (`/game/CODE`). The shell only
+ *  mounts under that route so the match is reliable; returns null in dev
+ *  harnesses or when the path shape differs (no chip rendered then). */
+function getGameCodeFromPath(): string | null {
+  if (typeof window === 'undefined') return null;
+  const m = window.location.pathname.match(/^\/game\/([A-Za-z0-9]+)/);
+  return m ? m[1] : null;
+}
 
 /**
  * View Transitions: each CastChip carries `data-chip-player-id`, and the
@@ -138,6 +148,16 @@ export function CastStrip() {
                 locked={locked}
               />,
             );
+          }
+          // Share chip — pregame only, hidden during picking mode
+          // (picking is a focused-action context; share would distract).
+          // Tail position so it reads as "extend the cast" rather than
+          // displacing real chips.
+          if (phase === DayPhases.PREGAME && !pickingMode) {
+            const gameCode = getGameCodeFromPath();
+            if (gameCode) {
+              rendered.push(<ShareChip key="__share-chip" gameCode={gameCode} />);
+            }
           }
           return rendered;
         })()}

--- a/apps/client/src/shells/pulse/components/caststrip/ShareChip.tsx
+++ b/apps/client/src/shells/pulse/components/caststrip/ShareChip.tsx
@@ -1,0 +1,119 @@
+import { memo, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { toast } from 'sonner';
+import { UserPlus } from '../../icons';
+import { PULSE_TAP } from '../../springs';
+
+const LOBBY_HOST = import.meta.env.VITE_LOBBY_HOST || 'http://localhost:3000';
+
+interface Props {
+  /** Invite code for the current game (e.g. "X7K2MP"). Read from URL by parent. */
+  gameCode: string;
+}
+
+/**
+ * Cast-strip chip that lets a player invite more friends to the game during
+ * pregame. Renders only while phase === pregame (parent-gated). Shape and
+ * footprint match CastChip so the strip's rhythm stays intact; the dashed
+ * border + muted background signal "empty seat / add someone" rather than
+ * a real player.
+ *
+ * Tap → navigator.share with the canonical /j/CODE URL. Falls back to
+ * clipboard.writeText + a toast confirmation when Web Share is unavailable
+ * (desktop browsers, older mobiles). The /j/CODE URL is the post-Phase-4
+ * frictionless welcome route — strangers who tap it land on the welcome
+ * form, returning players land on the right destination via the
+ * session-aware redirect.
+ *
+ * Tap feedback comes from `whileTap` (immediate scale-down) plus the
+ * native share sheet / toast — no keyframe-array animation needed
+ * (and would be unsafe here per the framer-motion keyframe-restart rule:
+ * cast strip re-renders constantly with store ticks).
+ */
+function ShareChipInner({ gameCode }: Props) {
+  const shareUrl = `${LOBBY_HOST}/j/${gameCode.toUpperCase()}`;
+
+  const handleTap = useCallback(async () => {
+    const shareData = {
+      title: 'Pecking Order',
+      text: `Join my game on Pecking Order — code ${gameCode.toUpperCase()}`,
+      url: shareUrl,
+    };
+
+    // Web Share API — preferred on mobile (opens native share sheet).
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        await navigator.share(shareData);
+        return;
+      } catch (err) {
+        // AbortError when user dismisses the share sheet — silent.
+        if ((err as DOMException)?.name === 'AbortError') return;
+        // Fall through to clipboard fallback on other failures.
+      }
+    }
+
+    // Clipboard fallback — desktop browsers, older mobiles, share sheet
+    // unavailable in standalone PWA on some platforms.
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      toast.success('Invite link copied');
+    } catch {
+      toast.error('Could not copy link — long-press the URL in the address bar');
+    }
+  }, [shareUrl, gameCode]);
+
+  return (
+    <motion.button
+      type="button"
+      onClick={handleTap}
+      whileTap={PULSE_TAP}
+      aria-label="Share game with more friends"
+      data-chip-share="true"
+      style={{
+        flex: '0 0 auto',
+        position: 'relative',
+        width: 56,
+        height: 56,
+        borderRadius: '50%',
+        // Dashed ring + transparent fill signals "open seat" without
+        // competing with real cast portraits visually.
+        border: '1.5px dashed color-mix(in oklch, var(--pulse-text-3) 55%, transparent)',
+        background: 'color-mix(in oklch, var(--pulse-surface) 60%, transparent)',
+        display: 'grid',
+        placeItems: 'center',
+        cursor: 'pointer',
+        outline: 'none',
+        padding: 0,
+        scrollSnapAlign: 'start',
+      }}
+      // Accessibility: focus ring matches Pulse focus convention.
+      onFocus={e => { e.currentTarget.style.outline = '2px solid var(--pulse-accent)'; e.currentTarget.style.outlineOffset = '2px'; }}
+      onBlur={e => { e.currentTarget.style.outline = 'none'; }}
+    >
+      <UserPlus
+        size={26}
+        weight="fill"
+        color="color-mix(in oklch, var(--pulse-text-2) 80%, transparent)"
+      />
+      <span
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          bottom: -16,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          fontSize: 9,
+          fontWeight: 700,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          color: 'color-mix(in oklch, var(--pulse-text-3) 70%, transparent)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        Invite
+      </span>
+    </motion.button>
+  );
+}
+
+export const ShareChip = memo(ShareChipInner);

--- a/apps/client/src/shells/pulse/components/caststrip/ShareChip.tsx
+++ b/apps/client/src/shells/pulse/components/caststrip/ShareChip.tsx
@@ -1,10 +1,50 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { motion } from 'framer-motion';
 import { toast } from 'sonner';
-import { UserPlus } from '../../icons';
-import { PULSE_TAP } from '../../springs';
+import { Plus } from '../../icons';
+import { PULSE_SPRING, PULSE_TAP } from '../../springs';
 
 const LOBBY_HOST = import.meta.env.VITE_LOBBY_HOST || 'http://localhost:3000';
+
+/** Async clipboard via `navigator.clipboard.writeText`. Browser-restricted to
+ *  secure contexts (HTTPS or localhost) — silently unavailable on plain-HTTP
+ *  origins like Tailscale dev. */
+async function tryAsyncClipboard(text: string): Promise<boolean> {
+  if (typeof navigator === 'undefined') return false;
+  if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Legacy clipboard via off-screen `<textarea>` + `document.execCommand`.
+ *  Deprecated in spec but still works on plain HTTP, which the modern
+ *  Clipboard API does not. */
+function tryLegacyCopy(text: string): boolean {
+  if (typeof document === 'undefined') return false;
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.top = '0';
+  ta.style.left = '0';
+  ta.style.opacity = '0';
+  ta.style.pointerEvents = 'none';
+  document.body.appendChild(ta);
+  ta.select();
+  ta.setSelectionRange(0, ta.value.length);
+  let ok = false;
+  try {
+    ok = document.execCommand('copy');
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(ta);
+  return ok;
+}
 
 interface Props {
   /** Invite code for the current game (e.g. "X7K2MP"). Read from URL by parent. */
@@ -12,106 +52,232 @@ interface Props {
 }
 
 /**
- * Cast-strip chip that lets a player invite more friends to the game during
- * pregame. Renders only while phase === pregame (parent-gated). Shape and
- * footprint match CastChip so the strip's rhythm stays intact; the dashed
- * border + muted background signal "empty seat / add someone" rather than
- * a real player.
+ * Cast-strip "open seat" chip — invites more friends during pregame. Renders
+ * only while phase === pregame (parent-gated). Footprint matches CastChip
+ * (72×100, --pulse-radius-md) so the chip reads as a real cast slot waiting
+ * to be filled, not a form control parachuted into a strip of portraits.
+ *
+ * Visual grammar (bolder pass):
+ *   • Bespoke SVG dashed ring (custom dash rhythm, warm cream tint) — reads
+ *     as an open seat "ribbon," not generic CSS dashed border.
+ *   • Confident silhouette (56×56, 2.4px strokes, cream warmth) sits where
+ *     a face would.
+ *   • Hero gold "+" badge — promoted from corner accessory to anchor mark.
+ *     Slow ambient breath (1800ms) signals "open invitation," calmer than
+ *     the 1000ms pending-invite urgency tempo.
+ *   • "INVITE" label tracked-caps in --pulse-gold (the project's signal
+ *     color, reserved for premium moments) — claims the open seat as
+ *     opportunity, not chore.
  *
  * Tap → navigator.share with the canonical /j/CODE URL. Falls back to
- * clipboard.writeText + a toast confirmation when Web Share is unavailable
- * (desktop browsers, older mobiles). The /j/CODE URL is the post-Phase-4
- * frictionless welcome route — strangers who tap it land on the welcome
- * form, returning players land on the right destination via the
- * session-aware redirect.
- *
- * Tap feedback comes from `whileTap` (immediate scale-down) plus the
- * native share sheet / toast — no keyframe-array animation needed
- * (and would be unsafe here per the framer-motion keyframe-restart rule:
- * cast strip re-renders constantly with store ticks).
+ * clipboard.writeText, then a legacy textarea copy, then a toast carrying
+ * the URL. Success → ignition beat: ring snaps solid gold, surface flushes
+ * gold, halo blooms, then settles back to calm.
  */
 function ShareChipInner({ gameCode }: Props) {
   const shareUrl = `${LOBBY_HOST}/j/${gameCode.toUpperCase()}`;
+  const [success, setSuccess] = useState(false);
 
   const handleTap = useCallback(async () => {
     const shareData = {
       title: 'Pecking Order',
-      text: `Join my game on Pecking Order — code ${gameCode.toUpperCase()}`,
+      text: `I'm in a game on Pecking Order — you're cast. Code ${gameCode.toUpperCase()}`,
       url: shareUrl,
     };
 
-    // Web Share API — preferred on mobile (opens native share sheet).
+    let landed = false;
+
     if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
       try {
         await navigator.share(shareData);
-        return;
+        landed = true;
       } catch (err) {
-        // AbortError when user dismisses the share sheet — silent.
+        // AbortError = user dismissed the share sheet. Treat as deliberate
+        // cancel (no fallback, no celebration).
         if ((err as DOMException)?.name === 'AbortError') return;
-        // Fall through to clipboard fallback on other failures.
       }
     }
 
-    // Clipboard fallback — desktop browsers, older mobiles, share sheet
-    // unavailable in standalone PWA on some platforms.
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-      toast.success('Invite link copied');
-    } catch {
-      toast.error('Could not copy link — long-press the URL in the address bar');
+    if (!landed) {
+      if ((await tryAsyncClipboard(shareUrl)) || tryLegacyCopy(shareUrl)) {
+        toast.success('Link copied — go cast someone');
+        landed = true;
+      } else {
+        toast.error(`Couldn't copy. Send this: ${shareUrl}`, { duration: 12_000 });
+        return;
+      }
     }
-  }, [shareUrl, gameCode]);
+
+    setSuccess(true);
+    window.setTimeout(() => setSuccess(false), 700);
+  }, [gameCode]);
+
+  // Stroke colors swap on success but stay as static rgba (not color-mix) so
+  // the SVG stroke transition can interpolate them.
+  const ringStroke = success ? 'rgba(255, 200, 61, 0.95)' : 'rgba(220, 200, 175, 0.55)';
+  const ringDash = success ? undefined : '7 5';
 
   return (
     <motion.button
       type="button"
       onClick={handleTap}
-      whileTap={PULSE_TAP}
-      aria-label="Share game with more friends"
+      whileTap={PULSE_TAP.card}
+      whileHover={{ scale: 1.02 }}
+      // Bolder entry: starts smaller (0.86) so the arrival lands with more
+      // presence. Delayed past the cast settle so it announces itself.
+      initial={{ scale: 0.86, opacity: 0 }}
+      animate={{ scale: 1, opacity: 1 }}
+      transition={{ delay: 0.2, ...PULSE_SPRING.pop }}
+      aria-label="Invite more friends to the game"
       data-chip-share="true"
       style={{
         flex: '0 0 auto',
         position: 'relative',
-        width: 56,
-        height: 56,
-        borderRadius: '50%',
-        // Dashed ring + transparent fill signals "open seat" without
-        // competing with real cast portraits visually.
-        border: '1.5px dashed color-mix(in oklch, var(--pulse-text-3) 55%, transparent)',
-        background: 'color-mix(in oklch, var(--pulse-surface) 60%, transparent)',
-        display: 'grid',
-        placeItems: 'center',
+        width: 72,
+        height: 100,
+        padding: 0,
+        border: 'none',
+        background: 'transparent',
+        borderRadius: 'var(--pulse-radius-md)',
         cursor: 'pointer',
         outline: 'none',
-        padding: 0,
         scrollSnapAlign: 'start',
       }}
-      // Accessibility: focus ring matches Pulse focus convention.
-      onFocus={e => { e.currentTarget.style.outline = '2px solid var(--pulse-accent)'; e.currentTarget.style.outlineOffset = '2px'; }}
-      onBlur={e => { e.currentTarget.style.outline = 'none'; }}
+      onFocus={e => {
+        if (e.currentTarget.matches(':focus-visible')) {
+          e.currentTarget.style.outline = '2px solid var(--pulse-accent)';
+          e.currentTarget.style.outlineOffset = '2px';
+        }
+      }}
+      onBlur={e => {
+        e.currentTarget.style.outline = 'none';
+      }}
     >
-      <UserPlus
-        size={26}
-        weight="fill"
-        color="color-mix(in oklch, var(--pulse-text-2) 80%, transparent)"
-      />
-      <span
-        aria-hidden="true"
+      {/* Surface — warmer/more saturated than v1 so the slot has presence
+          rather than receding. Success state flushes a soft gold wash. */}
+      <div
         style={{
           position: 'absolute',
-          bottom: -16,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          fontSize: 9,
-          fontWeight: 700,
-          letterSpacing: '0.08em',
-          textTransform: 'uppercase',
-          color: 'color-mix(in oklch, var(--pulse-text-3) 70%, transparent)',
-          whiteSpace: 'nowrap',
+          inset: 0,
+          borderRadius: 'var(--pulse-radius-md)',
+          overflow: 'hidden',
+          background: success
+            ? 'rgba(255, 200, 61, 0.10)'
+            : 'rgba(50, 35, 60, 0.55)',
+          boxShadow: success ? '0 0 22px rgba(255, 200, 61, 0.45)' : 'none',
+          transition: 'background 320ms ease, box-shadow 320ms ease',
         }}
       >
-        Invite
-      </span>
+        {/* Bespoke dashed ring — SVG so we control the dash rhythm (7 5),
+            stroke weight (2.5px), and color independently of CSS border
+            limitations. Snaps solid on success. */}
+        <svg
+          width="72"
+          height="100"
+          aria-hidden="true"
+          style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}
+        >
+          <rect
+            x="1.25"
+            y="1.25"
+            width="69.5"
+            height="97.5"
+            rx="12"
+            ry="12"
+            fill="none"
+            stroke={ringStroke}
+            strokeWidth="2.5"
+            strokeDasharray={ringDash}
+            style={{ transition: 'stroke 320ms ease' }}
+          />
+        </svg>
+
+        {/* Silhouette + hero gold "+". The badge anchors the composition;
+            the silhouette is the supporting cast (literally — it's the
+            face that hasn't arrived yet). */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'grid',
+            placeItems: 'center',
+            paddingBottom: 24,
+          }}
+        >
+          <div style={{ position: 'relative', width: 56, height: 56 }}>
+            <svg width="56" height="56" viewBox="0 0 56 56" aria-hidden="true">
+              {/* Head — larger and warmer than v1; reads as "real face waiting" */}
+              <circle
+                cx="28"
+                cy="20"
+                r="9.5"
+                fill="none"
+                stroke="rgba(255, 215, 195, 0.78)"
+                strokeWidth="2.4"
+              />
+              {/* Open shoulders arc — heavier stroke, warmer tint */}
+              <path
+                d="M11 49 C11 38, 18.5 33, 28 33 C37.5 33, 45 38, 45 49"
+                fill="none"
+                stroke="rgba(255, 215, 195, 0.78)"
+                strokeWidth="2.4"
+                strokeLinecap="round"
+              />
+            </svg>
+            {/* Hero gold "+". 26px dish (was 20), 15px glyph (was 11),
+                inset gold ring + outer halo. Slow ambient breath at 1800ms
+                — calmer tempo than pending-invite (1000ms), reads as
+                "open invitation" not "act now." Stops on success so the
+                ignition beat owns the moment. */}
+            <span
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                top: -6,
+                right: -8,
+                width: 26,
+                height: 26,
+                borderRadius: '50%',
+                background: 'rgba(8, 6, 12, 0.92)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                boxShadow:
+                  'inset 0 0 0 1.5px rgba(255, 200, 61, 0.85), 0 0 14px rgba(255, 200, 61, 0.5)',
+                animation: success
+                  ? undefined
+                  : 'pulse-breathe 1800ms ease-in-out infinite',
+              }}
+            >
+              <Plus size={15} weight="bold" color="#ffc83d" />
+            </span>
+          </div>
+        </div>
+
+        {/* "INVITE" — tracked-caps in --pulse-gold. The project's reveal-label
+            grammar (uppercase, heavy weight, wide tracking) scaled down for
+            chip context. Gold over the darker bottom gradient pops as a
+            premium opportunity, not utility chrome. */}
+        <div
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            bottom: 0,
+            padding: '14px 6px 5px',
+            background: 'linear-gradient(to top, rgba(0,0,0,0.92), transparent)',
+            color: 'var(--pulse-gold)',
+            fontSize: 11,
+            fontWeight: 900,
+            letterSpacing: '0.18em',
+            textAlign: 'center',
+            textTransform: 'uppercase',
+            textShadow: '0 1px 2px rgba(0,0,0,0.85)',
+          }}
+        >
+          Invite
+        </div>
+      </div>
     </motion.button>
   );
 }

--- a/apps/client/src/shells/pulse/icons.ts
+++ b/apps/client/src/shells/pulse/icons.ts
@@ -26,6 +26,7 @@ export {
   Lock,
   HandWaving,
   PencilSimple,
+  Plus,
   PlusCircle,
   UserPlus,
 

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -5,6 +5,14 @@ import { sentryVitePlugin } from '@sentry/vite-plugin'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    // Allow Tailscale-bound multi-device dev. Vite 5+ defaults to denying
+    // any host header that isn't localhost; the `--host 0.0.0.0` flag in
+    // dev opens the listener but doesn't whitelist the host header.
+    // `.ts.net` covers any Tailscale tailnet hostname; add specific
+    // hostnames if you want to be stricter.
+    allowedHosts: ['.ts.net', 'localhost', '127.0.0.1'],
+  },
   build: {
     sourcemap: true,
     rollupOptions: {

--- a/apps/game-server/package.json
+++ b/apps/game-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "clean": "rm -rf .wrangler/tmp",
-    "dev": "wrangler dev",
+    "dev": "wrangler dev --ip 0.0.0.0",
     "build": "tsc --noEmit",
     "test": "vitest run",
     "generate:docs": "npx tsx scripts/generate-machine-docs.ts",


### PR DESCRIPTION
## Summary

- Adds an in-game share chip at the tail of the Pulse cast strip, visible only during pregame phase. Tap → `navigator.share()` with the canonical `/j/CODE` URL; falls back to clipboard write + sonner toast on desktop / no-Web-Share contexts. Closes the deferred-feature item flagged in `docs/plans/2026-04-24-auth-flow-hardening.md` ("In-client share UI").
- Bundles four dev-config fixes that surfaced while verifying the chip over Tailscale multi-device dev — they're follow-on to `8043c69` (vite + next bound to 0.0.0.0), completing the same intent for the rest of the stack.

## Commits

1. **`feat(pulse): in-game share chip in cast strip during pregame`** — new `ShareChip.tsx` + render at the tail of `CastStrip.tsx`, gated on `phase === DayPhases.PREGAME && !pickingMode`. Uses Phosphor `UserPlus` (already exported), inline styles per Pulse convention, no keyframe-array animations (per the framer-motion-keyframe-restart guardrail).
2. **`chore(dev): allow .ts.net Tailscale hosts in Vite dev server`** — Vite 5+ defaults to denying non-localhost host headers; `--host 0.0.0.0` opens the listener but Tailscale URLs were still blocked. Adds `.ts.net` to `server.allowedHosts`.
3. **`fix(client): derive WS protocol from VITE_GAME_SERVER_HOST scheme`** — PartySocket defaulted to `wss://` for any non-localhost host, breaking Tailscale dev where the page is HTTP. Pass `protocol: 'ws' | 'wss'` explicitly, derived from the env-var scheme. Production unchanged (https → wss).
4. **`chore(dev): bind wrangler to 0.0.0.0 for multi-device dev`** — game-server's `wrangler dev` was missed in `8043c69`. Workerd was listening on `127.0.0.1` only, so Tailscale-routed clients couldn't reach the WS even after the host allowlist + protocol fixes.
5. **`feat(pulse): bolder cast-strip share chip — open-seat composition`** — visual polish on the chip: persona silhouette, gold ignition beat on success, footprint matches CastChip exactly so it reads as an empty cast slot rather than a form control.

Skipped from local history: `89cab6a fix(lobby/auth): only set cookie Domain on peckingorder.ca hosts` — already addressed upstream in #128's review-pass commit `4c301be` via a more general `isLocalHostname()` helper. No need to duplicate.

## Test plan

- [ ] Local dev (Tailscale or localhost): create a pregame CC game, open as any player, confirm a 5th tail-position chip appears in the cast strip with dashed ring + INVITE caption + UserPlus icon.
- [ ] Tap the chip:
  - On mobile (HTTPS context) — native share sheet opens with `${LOBBY_HOST}/j/CODE`.
  - On desktop (HTTPS) — clipboard write succeeds, sonner toast confirms "Link copied — go cast someone."
  - On desktop (plain HTTP, e.g. `localhost`) — legacy `execCommand('copy')` fallback fires, same toast.
- [ ] Advance the game past pregame (NEXT_STAGE) and confirm the chip disappears immediately (`phase` change unmounts).
- [ ] Verify the chip stays hidden during `pickingMode` (e.g. when adding members to a group DM).
- [ ] No regressions in cast-strip layout / scroll behavior — chip footprint matches CastChip's 72×100 box.

## Notes for review

- The chip's success animation uses `useState` + CSS transitions on border + box-shadow, deliberately avoiding framer-motion keyframe arrays in `animate` (per the in-tree guardrail — these silently break under per-tick re-renders in the cast strip).
- `CastStrip.tsx` parses the game code from `window.location.pathname`; safe under SSR via `typeof window === 'undefined'` guard.
- The clipboard fallback chain (Web Share → async clipboard → legacy textarea → toast with raw URL) handles all combinations of mobile/desktop × HTTPS/HTTP. The legacy fallback exists specifically because `navigator.clipboard` requires a secure context and isn't available on plain HTTP.
- The three dev-config commits (`40bf456`, `514dc94`, `353e75d`) are independently useful — split into separate commits for easy revert if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)