### PR TITLE
fix(game-status): defer IN_PROGRESS callback until L2 leaves preGame

### DIFF
--- a/apps/game-server/src/__tests__/subscription-status.test.ts
+++ b/apps/game-server/src/__tests__/subscription-status.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { shouldFireInProgress } from '../subscription';
+
+// Regression coverage for the staging defect where PR #130 fired the
+// IN_PROGRESS → lobby STARTED callback at /init time. CC games auto-init at
+// game-CREATE time (before any invitee has clicked their email link), so
+// the lobby flipped to STARTED prematurely and getInviteInfo() rejected
+// every subsequent invitee with "this game is no longer accepting players".
+//
+// The fixed gate lives in subscription.ts and fires only once L2 has left
+// preGame — the same threshold handlePlayerJoined uses to 409 late joiners.
+describe('shouldFireInProgress (PR #130 regression gate)', () => {
+  describe('does NOT fire while L2 is in pre-game states', () => {
+    it('returns false for snapshot.value === "preGame"', () => {
+      expect(shouldFireInProgress('preGame', 'game-1', false)).toBe(false);
+    });
+
+    it('returns false for snapshot.value === "uninitialized"', () => {
+      expect(shouldFireInProgress('uninitialized', 'game-1', false)).toBe(false);
+    });
+  });
+
+  describe('fires once L2 has left preGame', () => {
+    it('returns true on the dayLoop compound state object', () => {
+      // dayLoop is a compound state, so snapshot.value is `{ dayLoop: ... }`
+      // (object). The gate must accept this without enumerating substates.
+      expect(shouldFireInProgress({ dayLoop: 'morningBriefing' }, 'game-1', false)).toBe(true);
+      expect(
+        shouldFireInProgress(
+          { dayLoop: { activeSession: 'waitingForChild' } },
+          'game-1',
+          false,
+        ),
+      ).toBe(true);
+      expect(shouldFireInProgress({ dayLoop: 'nightSummary' }, 'game-1', false)).toBe(true);
+    });
+
+    it('returns true for terminal post-game states', () => {
+      // If a game somehow reached gameSummary/gameOver without ever flipping
+      // STARTED (e.g. snapshot recovery edge case), we still want STARTED to
+      // fire — the lobby route's monotonic DAG keeps COMPLETED ahead anyway.
+      expect(shouldFireInProgress('gameSummary', 'game-1', false)).toBe(true);
+      expect(shouldFireInProgress('gameOver', 'game-1', false)).toBe(true);
+    });
+  });
+
+  describe('idempotency', () => {
+    it('returns false once alreadyNotified is true (post-restart)', () => {
+      // After the persisted flag is read on onStart, subscription must not
+      // re-fire the callback for any subsequent tick — including the first
+      // synchronous restore fire.
+      expect(shouldFireInProgress({ dayLoop: 'morningBriefing' }, 'game-1', true)).toBe(false);
+      expect(shouldFireInProgress('gameSummary', 'game-1', true)).toBe(false);
+    });
+  });
+
+  describe('gameId guards', () => {
+    it('returns false when gameId is empty', () => {
+      expect(shouldFireInProgress({ dayLoop: 'morningBriefing' }, '', false)).toBe(false);
+    });
+
+    it('returns false when gameId is undefined', () => {
+      expect(
+        shouldFireInProgress({ dayLoop: 'morningBriefing' }, undefined, false),
+      ).toBe(false);
+    });
+
+    it('returns false when gameId is not a string', () => {
+      expect(
+        shouldFireInProgress({ dayLoop: 'morningBriefing' }, 42 as unknown, false),
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/game-server/src/http-handlers.ts
+++ b/apps/game-server/src/http-handlers.ts
@@ -4,7 +4,6 @@ import type { orchestratorMachine } from "./machines/l2-orchestrator";
 import { Events, FactTypes, GameManifestSchema } from "@pecking-order/shared-types";
 import { readGoldBalances, insertGameAndPlayers, getPushSubscriptionD1, deletePushSubscriptionD1 } from "./d1-persistence";
 import { sendPushNotification } from "./push-send";
-import { notifyLobbyGameStatus } from "./lobby-callback";
 import { log } from "./log";
 import type { Env } from "./types";
 
@@ -149,12 +148,13 @@ async function handleInit(ctx: HandlerContext, req: Request, url: URL): Promise<
 
     insertGameAndPlayers(ctx.env.DB, gameId, json.manifest?.gameMode || json.manifest?.scheduling || 'CONFIGURABLE_CYCLE', json.roster || {});
 
-    // Notify lobby — bridges game-server IN_PROGRESS to lobby STARTED.
-    // Covers both STATIC games (lobby's startGame already self-marks STARTED;
-    // this is idempotent) and CC games (whose only prior trigger was a 409
-    // from a late joiner — issue #49). waitUntil keeps the fetch alive past
-    // the response boundary so the isolate isn't evicted mid-flight.
-    ctx.waitUntil(notifyLobbyGameStatus(ctx.env, gameId, 'IN_PROGRESS'));
+    // The IN_PROGRESS → lobby STARTED callback used to fire here, but DO
+    // auto-init for CC games happens at game-CREATE time (before any invitee
+    // has clicked their email link). Flipping the lobby to STARTED at that
+    // moment makes getInviteInfo() reject every subsequent invitee with
+    // "this game is no longer accepting players" — a regression introduced
+    // by PR #130 and seen on staging (PHH3FJ). The callback now lives in
+    // subscription.ts gated on L2 leaving preGame.
 
     return new Response(JSON.stringify({ status: "OK" }), { status: 200 });
   } catch (err) {

--- a/apps/game-server/src/server.ts
+++ b/apps/game-server/src/server.ts
@@ -12,7 +12,7 @@ import { handleConnect, handleMessage, handleClose, rebuildConnectedPlayers, typ
 import { setupActorSubscription, type SubscriptionState } from "./subscription";
 import { handleGlobalRoutes } from "./global-routes";
 import { buildActionOverrides, type ActionContext } from "./machine-actions";
-import { ensureSnapshotsTable, readSnapshot, readGoldCredited, readD1CompletionWritten, readLobbyCompletionNotified, parseSnapshot } from "./snapshot";
+import { ensureSnapshotsTable, readSnapshot, readGoldCredited, readD1CompletionWritten, readLobbyCompletionNotified, readLobbyStartedNotified, parseSnapshot } from "./snapshot";
 
 export { DemoServer } from './demo/demo-server';
 export type { Env } from "./types";
@@ -33,6 +33,7 @@ export class GameServer extends Server<Env> {
   goldCredited = false;
   d1CompletionWritten = false;
   lobbyCompletionNotified = false;
+  lobbyStartedNotified = false;
   connectedPlayers = new Map<string, Set<string>>();
   inspectSubscribers = new Set<Connection>();
 
@@ -107,6 +108,7 @@ export class GameServer extends Server<Env> {
     this.goldCredited = await readGoldCredited(this.ctx.storage);
     this.d1CompletionWritten = readD1CompletionWritten(this.ctx.storage);
     this.lobbyCompletionNotified = readLobbyCompletionNotified(this.ctx.storage);
+    this.lobbyStartedNotified = readLobbyStartedNotified(this.ctx.storage);
 
     // 3. Create machine with DO-context action overrides
     const machine = orchestratorMachine.provide({
@@ -208,11 +210,12 @@ export class GameServer extends Server<Env> {
    *  onStart, defeating the wipe (review follow-up). */
   private async wipeRunStateOnCorruption(): Promise<void> {
     this.ctx.storage.sql.exec(
-      "DELETE FROM snapshots WHERE key IN ('game_state','d1_completion_written','lobby_completion_notified','gold_credited')"
+      "DELETE FROM snapshots WHERE key IN ('game_state','d1_completion_written','lobby_completion_notified','lobby_started_notified','gold_credited')"
     );
     await this.ctx.storage.delete(['goldCredited', 'game_state_snapshot']);
     this.d1CompletionWritten = false;
     this.lobbyCompletionNotified = false;
+    this.lobbyStartedNotified = false;
     this.goldCredited = false;
   }
 

--- a/apps/game-server/src/snapshot.ts
+++ b/apps/game-server/src/snapshot.ts
@@ -83,6 +83,9 @@ export function readD1CompletionWritten(storage: DurableObjectStorage): boolean 
 export function readLobbyCompletionNotified(storage: DurableObjectStorage): boolean {
   return readBooleanFlag(storage, 'lobby_completion_notified');
 }
+export function readLobbyStartedNotified(storage: DurableObjectStorage): boolean {
+  return readBooleanFlag(storage, 'lobby_started_notified');
+}
 
 /** Result of parsing a stored snapshot for actor restoration. */
 export interface ParsedSnapshot {

--- a/apps/game-server/src/subscription.ts
+++ b/apps/game-server/src/subscription.ts
@@ -11,6 +11,29 @@ import { log } from "./log";
 import type { Env } from "./types";
 import { getOnlinePlayerIds } from "./ws-handlers";
 
+/**
+ * Pure gate for the IN_PROGRESS → lobby STARTED callback. Fires once when
+ * L2 first leaves `preGame` (i.e. when joiners are no longer accepted —
+ * handlePlayerJoined already 409s past preGame). dayLoop is a compound
+ * state so `snapshot.value` is `{ dayLoop: ... }` (object); excluding only
+ * the two simple pre-game atomic states keeps this correct without
+ * enumerating dayLoop's substates.
+ *
+ * The original PR #130 fired this at /init time, which broke email
+ * invites: invitees who hadn't yet clicked their link found the game
+ * already STARTED and were rejected by getInviteInfo() with "this game is
+ * no longer accepting players".
+ */
+export function shouldFireInProgress(
+  l2State: unknown,
+  gameId: unknown,
+  alreadyNotified: boolean,
+): boolean {
+  if (alreadyNotified) return false;
+  if (typeof gameId !== 'string' || gameId.length === 0) return false;
+  return l2State !== 'uninitialized' && l2State !== 'preGame';
+}
+
 /** Mutable state owned by the server, updated by the subscription callback. */
 export interface SubscriptionState {
   lastKnownChatLog: any[];
@@ -27,6 +50,11 @@ export interface SubscriptionState {
    *  full retry-on-failure is a future improvement. Issue #49 review. */
   d1CompletionWritten: boolean;
   lobbyCompletionNotified: boolean;
+  /** IN_PROGRESS → lobby STARTED is fired exactly once on the first
+   *  subscription tick where L2 has left preGame (the original PR #130
+   *  fired this on /init, which broke email invites — invitees would land
+   *  on a STARTED game that no longer accepted joiners). */
+  lobbyStartedNotified: boolean;
 }
 
 export interface SubscriptionDeps {
@@ -133,6 +161,17 @@ export function setupActorSubscription(
     // states are simple strings) avoids any substring collision with L3
     // state JSON.
     const l2State = snapshot.value;
+
+    // IN_PROGRESS → lobby STARTED. See shouldFireInProgress() for the gate
+    // rationale and the regression it prevents.
+    if (shouldFireInProgress(l2State, snapshot.context.gameId, state.lobbyStartedNotified)) {
+      state.lobbyStartedNotified = true;
+      deps.storage.sql.exec(
+        `INSERT OR REPLACE INTO snapshots (key, value, updated_at) VALUES ('lobby_started_notified', 'true', unixepoch())`
+      );
+      deps.waitUntil(notifyLobbyGameStatus(deps.env, snapshot.context.gameId, 'IN_PROGRESS'));
+    }
+
     const isGameEnded = l2State === 'gameSummary' || l2State === 'gameOver';
     if (isGameEnded && snapshot.context.gameId) {
       // game-server D1: write Games.status='COMPLETED' once.

--- a/apps/lobby/app/j/[code]/page.tsx
+++ b/apps/lobby/app/j/[code]/page.tsx
@@ -24,9 +24,35 @@ export default async function FrictionlessWelcomePage({ params }: PageProps) {
 
   if (!game) notFound();
 
+  // Resolve session + enrollment up front so already-joined players who
+  // return to the email link AFTER game start bypass the "no longer
+  // accepting players" wall and get funneled into /play. The previous
+  // ordering ran the !isAcceptingPlayers gate first, which blocked enrolled
+  // players too — surfaced once PR #130 began flipping STARTED at the
+  // right moment instead of leaving CC games stuck at RECRUITING.
+  //
+  // D1 is eventually-consistent across replicas; an Invites row written
+  // sub-second ago might miss here and show the welcome form instead of
+  // redirecting. Next reload picks it up. Acceptable residual gap.
+  const session = await getSession();
+  const enrolled = session
+    ? !!(await db
+        .prepare('SELECT id FROM Invites WHERE game_id = ? AND accepted_by = ?')
+        .bind(game.id, session.userId)
+        .first())
+    : false;
+
+  // Already-joined player coming back to a started/completed game →
+  // /play mints a fresh JWT and forwards into the client.
+  if (enrolled && (game.status === 'STARTED' || game.status === 'COMPLETED')) {
+    redirect(`/play/${code}`);
+  }
+
   const isAcceptingPlayers = game.status === 'RECRUITING' || game.status === 'READY';
 
   if (!isAcceptingPlayers) {
+    // Unenrolled visitor (or admin-archived game) post-start. Genuinely
+    // can't join.
     return (
       <div className="min-h-dvh flex items-center justify-center bg-skin-deep px-5 py-8">
         <div className="max-w-md text-center space-y-4">
@@ -42,25 +68,13 @@ export default async function FrictionlessWelcomePage({ params }: PageProps) {
     );
   }
 
-  // Short-circuit based on visitor session:
-  //   authed + not enrolled    → /join (persona pick)
-  //   authed + enrolled + STARTED → /play (into the running game)
-  //   anon OR authed + enrolled + pre-start → fall through to the welcome
-  //     view so the visitor sees the joined cast + social context. /play
-  //     would bounce pre-start players into /game/CODE/waiting (host
-  //     panel, reads as empty for non-host enrolled players).
-  // D1 is eventually-consistent across replicas; an Invites row written
-  // sub-second ago might miss here and show the welcome form instead of
-  // redirecting. Next reload picks it up. Acceptable residual gap.
-  const session = await getSession();
-  if (session) {
-    const enrolled = await db
-      .prepare('SELECT id FROM Invites WHERE game_id = ? AND accepted_by = ?')
-      .bind(game.id, session.userId)
-      .first();
-    if (!enrolled) redirect(`/join/${code}`);
-    if (game.status === 'STARTED' || game.status === 'COMPLETED') redirect(`/play/${code}`);
-    // enrolled + RECRUITING/READY → render the welcome view below.
+  // Authed + not enrolled + still accepting → persona pick.
+  // Anon OR authed + enrolled + pre-start → fall through to the welcome
+  // view so the visitor sees the joined cast + social context. /play
+  // would otherwise bounce pre-start players into /game/CODE/waiting
+  // (host panel, reads as empty for non-host enrolled players).
+  if (session && !enrolled) {
+    redirect(`/join/${code}`);
   }
 
   // Joined cast: fetch up to 6 accepted players with persona + user labels,


### PR DESCRIPTION
## Summary
Live regression fix for staging — PR #130's IN_PROGRESS → lobby STARTED callback fired at `/init` time, so CC games (which auto-init at game-CREATE time) flipped the lobby row to STARTED before any invitee had clicked their email link. Subsequent invitees were rejected by `getInviteInfo()` with "this game is no longer accepting players" (rendered as "Invalid Invite" on `/join/[code]`).

Repro on staging: invite code **PHH3FJ**, internal id `game-1777153758608-675`. Axiom: 21:49:18Z host `/init` → 21:49:19Z lobby got IN_PROGRESS POST → 21:49:54Z first invitee POSTed `/invite/<token>` and bounced.

## Fix
- Remove the `notifyLobbyGameStatus(..., 'IN_PROGRESS')` call from `apps/game-server/src/http-handlers.ts` `/init` handler.
- Add a new `shouldFireInProgress()` gate in `apps/game-server/src/subscription.ts` that fires once on the first subscription tick where L2 has left `preGame` — the same threshold `handlePlayerJoined` uses to 409 late joiners.
- `dayLoop` is a compound state, so `snapshot.value` becomes `{ dayLoop: ... }` (object); excluding only the two simple atomic pre-game states (`uninitialized`, `preGame`) keeps the gate correct without enumerating dayLoop's substates.
- New persisted `lobby_started_notified` snapshots-table flag, reader, and wipe path — mirrors the existing `lobby_completion_notified` pattern.

## Test plan
- [x] New `apps/game-server/src/__tests__/subscription-status.test.ts` (8 cases): returns false for `preGame` / `uninitialized`, true for `dayLoop` compound shapes (string + nested object) and the post-game terminal states, idempotent once `alreadyNotified=true`, plus gameId guards (empty / undefined / non-string).
- [x] Full suites: **461/461** game-server (+8 new), **79/79** lobby. `tsc --noEmit` clean both apps.
- [ ] **Staging E2E (post-deploy)**: create a fresh CC game, host opens room, invitee clicks email link → invitee should land on `/join/[code]` persona-pick screen, NOT "Invalid Invite". The CI auto-deploys staging on push to `fix/*` branches.

## Out of scope
- The "Invalid Invite" heading on `/join/[code]/page.tsx` is misleading when the cause is "game already started" — worth distinct headings per `getInviteInfo()` error case. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)