### PR TITLE
polish(lobby): brand mantra, typography, contrast + invite/share UX

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -363,7 +363,13 @@ function applyToken(
   // Set game-specific cookie (iOS 17.2+ copies cookies from Safari to standalone PWA)
   setPwaAuthCookie(key, jwt);
 
-  // Clean transient params from URL
+  // Clean transient params from URL — but stash debug params first so the
+  // Pulse hooks can pick them up after the strip.
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    const forceUrgent = params.get('force-urgent');
+    if (forceUrgent) sessionStorage.setItem('po-force-urgent', forceUrgent);
+  }
   if (gameCode) {
     window.history.replaceState({}, '', `/game/${gameCode}`);
   }

--- a/apps/client/src/shells/pulse/components/EdgePin.tsx
+++ b/apps/client/src/shells/pulse/components/EdgePin.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import type { PillState } from '../hooks/usePillStates';
+
+/**
+ * EdgePin — when the active/urgent pill is scrolled out of view in the pill
+ * row, show a small accent-pink pin at the row's edge that recenters on tap.
+ *
+ * "Loud on purpose": the pin only appears when the player has navigated away
+ * from the live pill, never during normal scroll-on-state-change. Calm by
+ * default; the pink ring asks for attention only when the live signal would
+ * otherwise be missed.
+ */
+interface EdgePinProps {
+  scrollContainer: HTMLDivElement | null;
+  pills: PillState[];
+  pillNodes: Record<string, HTMLButtonElement | null>;
+  /** Override Date.now() for tests (controls "live" pill detection). */
+  now?: number;
+}
+
+export function EdgePin({ scrollContainer, pills, pillNodes, now }: EdgePinProps) {
+  const [state, setState] = useState<{
+    visible: boolean;
+    side: 'left' | 'right';
+    pillId: string | null;
+    label: string;
+  }>({ visible: false, side: 'right', pillId: null, label: '' });
+
+  useEffect(() => {
+    if (!scrollContainer) return;
+
+    // Pick the most-urgent pill to track. Order: urgent > active needs-action
+    // (cartridge) > acted. Social windows aren't pinned (they're long, calm,
+    // and pinning them would noise up the row constantly).
+    const target = findLiveCartridge(pills);
+
+    const update = () => {
+      if (!target) {
+        setState((s) => (s.visible ? { ...s, visible: false } : s));
+        return;
+      }
+      const node = pillNodes[target.id];
+      if (!node) return;
+      const wrapRect = scrollContainer.getBoundingClientRect();
+      const pillRect = node.getBoundingClientRect();
+      const visible = pillRect.right > wrapRect.left + 24 && pillRect.left < wrapRect.right - 24;
+
+      if (visible) {
+        setState((s) => (s.visible ? { ...s, visible: false } : s));
+      } else {
+        const side: 'left' | 'right' = pillRect.left < wrapRect.left ? 'left' : 'right';
+        setState({ visible: true, side, pillId: target.id, label: target.label });
+      }
+    };
+
+    update();
+    scrollContainer.addEventListener('scroll', update, { passive: true });
+    window.addEventListener('resize', update);
+    // Periodic refresh for live countdowns / pill state changes that don't
+    // trigger scroll events (e.g., the row reorders on its own).
+    const tickId = window.setInterval(update, 1000);
+    return () => {
+      scrollContainer.removeEventListener('scroll', update);
+      window.removeEventListener('resize', update);
+      window.clearInterval(tickId);
+    };
+  }, [scrollContainer, pills, pillNodes, now]);
+
+  if (!state.visible || !state.pillId) return null;
+
+  const handleTap = () => {
+    if (!scrollContainer || !state.pillId) return;
+    const node = pillNodes[state.pillId];
+    if (!node) return;
+    const wrapRect = scrollContainer.getBoundingClientRect();
+    const pillRect = node.getBoundingClientRect();
+    const targetLeft =
+      scrollContainer.scrollLeft + (pillRect.left - wrapRect.left) - scrollContainer.clientWidth / 2 + pillRect.width / 2;
+    scrollContainer.scrollTo({ left: targetLeft, behavior: 'smooth' });
+  };
+
+  const arrow = state.side === 'left' ? '←' : '→';
+
+  return (
+    <motion.button
+      data-testid="pulse-edge-pin"
+      onClick={handleTap}
+      initial={{ opacity: 0, scale: 0.85 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.85 }}
+      style={{
+        position: 'absolute',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        [state.side]: 14,
+        zIndex: 4,
+        background: 'var(--pulse-surface-3)',
+        border: '1.5px solid var(--pulse-accent)',
+        color: 'var(--pulse-accent)',
+        fontFamily: 'var(--po-font-display, var(--po-font-body))',
+        fontSize: 12,
+        fontWeight: 800,
+        letterSpacing: 0.06 * 12,
+        padding: '8px 12px',
+        borderRadius: 'var(--pulse-radius-xl, 100px)',
+        cursor: 'pointer',
+        boxShadow:
+          '0 4px 18px color-mix(in oklch, var(--pulse-accent) 45%, transparent), 0 0 0 4px color-mix(in oklch, var(--pulse-accent) 10%, transparent)',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        textTransform: 'uppercase',
+      }}
+    >
+      <span aria-hidden="true">{state.side === 'left' ? arrow : ''}</span>
+      <span>{state.label}</span>
+      <span aria-hidden="true">{state.side === 'right' ? arrow : ''}</span>
+    </motion.button>
+  );
+}
+
+function findLiveCartridge(pills: PillState[]): PillState | null {
+  const cartridge = (p: PillState) =>
+    p.kind === 'voting' || p.kind === 'game' || p.kind === 'prompt' || p.kind === 'dilemma';
+  return (
+    pills.find((p) => cartridge(p) && p.lifecycle === 'urgent') ||
+    pills.find((p) => cartridge(p) && p.lifecycle === 'needs-action') ||
+    pills.find((p) => cartridge(p) && p.lifecycle === 'in-progress') ||
+    null
+  );
+}

--- a/apps/client/src/shells/pulse/components/NowLine.tsx
+++ b/apps/client/src/shells/pulse/components/NowLine.tsx
@@ -1,0 +1,215 @@
+import { useMemo } from 'react';
+import { useDayPhase, type DayPhase, type PillState } from '../hooks/usePillStates';
+import { useNowTick } from '../hooks/useNowTick';
+import { useGameStore } from '../../../store/useGameStore';
+
+/**
+ * NowLine — a single tracked-caps line above the pill row that names the
+ * day's most-relevant *now* and *next* events. Tells the day at speech speed;
+ * the pills underneath are the visual map.
+ *
+ * Algorithm (priority order for the Now slot):
+ *   1. urgent cartridge        → Now goes pink ("has-urgent")
+ *   2. active cartridge        → Now is body color
+ *   3. acted (in-progress)     → Now is body color (you're in)
+ *   4. social-window active    → Now is faded; Next gets gold emphasis
+ *   5. nothing live            → "Day clear"
+ *
+ * Next slot:
+ *   - Next upcoming pill (chronologically), with relative or wall-clock
+ *     time depending on distance. < 60min → "in 5m". ≥ 60min → "16:00".
+ *   - If no upcoming → boundary's countdown ("Day ends · in 12m").
+ */
+interface NowLineProps {
+  pills: PillState[];
+  /** Override Date.now() for tests. */
+  now?: number;
+}
+
+export function NowLine({ pills, now }: NowLineProps) {
+  // Re-render every second so the "Next · in 5m" copy ticks live. The Now
+  // copy already ticks because pill.meta strings are recomputed in
+  // usePillStates each second, but the Next slot does its own time-math.
+  const tickNow = useNowTick(1000, now === undefined);
+  const effectiveNow = now ?? tickNow;
+  const phase = useDayPhase();
+  const dayIndex = useGameStore((s) => s.dayIndex);
+  const computed = useMemo(
+    () => computeNowLine(pills, effectiveNow, phase, dayIndex),
+    [pills, effectiveNow, phase, dayIndex],
+  );
+  if (!computed) return null;
+
+  const { nowText, nextText, hasUrgent, isFaded } = computed;
+
+  return (
+    <div
+      data-testid="pulse-now-line"
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        justifyContent: 'space-between',
+        gap: 12,
+        padding: '8px 12px 4px',
+        flexWrap: 'wrap',
+        fontFamily: 'var(--po-font-display, var(--po-font-body))',
+        fontSize: 10,
+        letterSpacing: 0.22 * 10,
+        textTransform: 'uppercase',
+        fontWeight: 800,
+        color: 'var(--pulse-text-3)',
+        background: 'var(--pulse-surface)',
+        borderBottom: '1px solid var(--pulse-border)',
+      }}
+    >
+      <Slot
+        labelText="Now"
+        bodyText={nowText}
+        labelColor={hasUrgent ? 'var(--pulse-accent)' : 'var(--pulse-text-3)'}
+        bodyColor={
+          hasUrgent
+            ? 'var(--pulse-accent)'
+            : isFaded
+              ? 'var(--pulse-text-3)'
+              : 'var(--pulse-text-1)'
+        }
+      />
+      <Slot
+        labelText="Next"
+        bodyText={nextText}
+        labelColor={isFaded ? 'var(--pulse-gold)' : 'var(--pulse-text-3)'}
+        bodyColor={isFaded ? 'var(--pulse-gold)' : 'var(--pulse-text-1)'}
+      />
+    </div>
+  );
+}
+
+function Slot({
+  labelText,
+  bodyText,
+  labelColor,
+  bodyColor,
+}: {
+  labelText: string;
+  bodyText: string;
+  labelColor: string;
+  bodyColor: string;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <span style={{ color: labelColor }}>{labelText}</span>
+      <span style={{ color: bodyColor }}>{bodyText}</span>
+    </div>
+  );
+}
+
+/**
+ * Pure derivation of now-line copy from a pill array. Exported for tests.
+ *
+ * Phase awareness:
+ *   - pregame: Now = "Pregame", Next = "Day N · in Xm" from boundary
+ *   - day:     Now = primary active (or "Day clear"), Next = next upcoming
+ *   - night:   Now = "Night", Next = "Day N+1 · in Xh Ym"
+ */
+export function computeNowLine(
+  pills: PillState[],
+  now: number,
+  phase: DayPhase = 'day',
+  dayIndex: number = 1,
+): { nowText: string; nextText: string; hasUrgent: boolean; isFaded: boolean } | null {
+  if (pills.length === 0) return null;
+
+  const boundary = pills.find((p) => p.kind === 'boundary');
+
+  // Pregame: nothing's live; the boundary anchor is the only meaningful copy.
+  if (phase === 'pregame') {
+    const startMs = boundary?.startTime ?? boundary?.endTime;
+    return {
+      nowText: 'Pregame',
+      nextText:
+        startMs !== undefined
+          ? `Day ${dayIndex} · in ${formatRelative(startMs - now)}`
+          : `Day ${dayIndex} · soon`,
+      hasUrgent: false,
+      isFaded: true,
+    };
+  }
+
+  // Night: day has ended; surface tomorrow's anchor explicitly. The previous
+  // copy ("Day ends · in 5h 35m") read as nonsense in this phase.
+  if (phase === 'night') {
+    const nextOpenMs = boundary?.endTime;
+    return {
+      nowText: 'Night',
+      nextText:
+        nextOpenMs !== undefined
+          ? `Day ${dayIndex + 1} · in ${formatRelative(nextOpenMs - now)}`
+          : `Day ${dayIndex + 1} · soon`,
+      hasUrgent: false,
+      isFaded: true,
+    };
+  }
+
+  // Day: pick the most-action-relevant active pill for Now.
+  const cartridgePills = pills.filter(
+    (p) => p.kind === 'voting' || p.kind === 'game' || p.kind === 'prompt' || p.kind === 'dilemma',
+  );
+  const urgent = pills.find((p) => p.lifecycle === 'urgent' && p.kind !== 'boundary');
+  const activeCartridge = cartridgePills.find((p) => p.lifecycle === 'needs-action');
+  const actedCartridge = cartridgePills.find((p) => p.lifecycle === 'in-progress');
+  const activeWindow = pills.find((p) => p.isSocialWindow && p.lifecycle === 'needs-action');
+  const primary = urgent || activeCartridge || actedCartridge || activeWindow;
+
+  let nowText: string;
+  if (primary) {
+    nowText = primary.meta ? `${primary.label} · ${primary.meta}` : `${primary.label} · live`;
+  } else {
+    nowText = 'Day clear';
+  }
+
+  // Fade Now if the primary is a passive long-window with > 60min remaining
+  // and no urgent cartridge is competing for attention.
+  const isFaded = !!(
+    !urgent &&
+    primary?.isSocialWindow &&
+    primary.endTime &&
+    primary.endTime - now > 60 * 60 * 1000
+  );
+
+  // Next: first upcoming pill chronologically (boundary excluded — that's the
+  // day-end anchor, not "what's next on the timeline"). Fall back to boundary.
+  const upcoming = pills
+    .filter((p) => p.lifecycle === 'upcoming' && p.kind !== 'boundary')
+    .sort((a, b) => (a.startTime ?? 0) - (b.startTime ?? 0));
+  const next = upcoming[0];
+
+  let nextText: string;
+  if (next && next.startTime !== undefined) {
+    const minsTo = (next.startTime - now) / 60_000;
+    nextText =
+      minsTo < 60
+        ? `${next.label} · in ${formatRelative(next.startTime - now)}`
+        : `${next.label} · ${formatClock(next.startTime)}`;
+  } else if (boundary && boundary.endTime !== undefined) {
+    nextText = `Day ends · in ${formatRelative(boundary.endTime - now)}`;
+  } else {
+    nextText = '—';
+  }
+
+  return { nowText, nextText, hasUrgent: !!urgent, isFaded };
+}
+
+/** "5m" / "1h 30m" — used after "in" prefix; no trailing "left". */
+function formatRelative(ms: number): string {
+  const m = Math.max(0, Math.floor(ms / 60_000));
+  if (m < 1) return `${Math.max(0, Math.floor(ms / 1000))}s`;
+  if (m < 60) return `${m}m`;
+  const hh = Math.floor(m / 60);
+  const mm = m % 60;
+  return mm === 0 ? `${hh}h` : `${hh}h ${String(mm).padStart(2, '0')}m`;
+}
+
+function formatClock(ms: number): string {
+  const d = new Date(ms);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}

--- a/apps/client/src/shells/pulse/components/Pill.tsx
+++ b/apps/client/src/shells/pulse/components/Pill.tsx
@@ -1,61 +1,44 @@
 import { useEffect, useRef, useState } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
-import { ChartBar, GameController, ChatCircleDots, Scales } from '../icons';
+import { ChartBar, GameController, ChatCircleDots, Scales, ChatCircle, UsersThree, Clock } from '../icons';
 import { PULSE_SPRING, PULSE_TAP } from '../springs';
-import type { PillState, PillLifecycle } from '../hooks/usePillStates';
+import { ACT_VERB, type PillState, type PillLifecycle, type PillKind, type CartridgeKind } from '../hooks/usePillStates';
+import { useNowTick } from '../hooks/useNowTick';
 
-const PILL_ICONS: Record<string, typeof ChartBar> = {
+const PILL_ICONS: Record<PillKind, typeof ChartBar> = {
   voting: ChartBar,
   game: GameController,
   prompt: ChatCircleDots,
   dilemma: Scales,
+  dms: ChatCircle,
+  group: UsersThree,
+  boundary: Clock,
 };
 
-const PILL_COLORS: Record<string, string> = {
+const PILL_COLORS: Record<PillKind, string> = {
   voting: 'var(--pulse-vote)',
   game: 'var(--pulse-game)',
   prompt: 'var(--pulse-prompt)',
   dilemma: 'var(--pulse-dilemma)',
+  dms: 'var(--pulse-social)',
+  group: 'var(--pulse-social)',
+  boundary: 'var(--pulse-gold)',
 };
 
-function lifecycleStyles(lifecycle: PillLifecycle) {
-  switch (lifecycle) {
-    case 'upcoming':
-      return {
-        background: 'var(--pulse-surface-2)',
-        border: '1px dashed var(--pulse-text-4)',
-        // Breathing opacity — "coming, don't forget me" instead of "disabled".
-        animation: 'pulse-pill-upcoming 3s ease-in-out infinite',
-      };
-    case 'starting':
-    case 'just-started':
-      return {
-        background: 'var(--pulse-surface-2)',
-        border: '1px solid var(--pulse-accent)',
-      };
-    case 'needs-action':
-      return {
-        background: 'var(--pulse-accent-glow)',
-        border: '1px solid var(--pulse-accent)',
-      };
-    case 'urgent':
-      return {
-        background: 'var(--pulse-accent-glow)',
-        border: '1px solid var(--pulse-accent)',
-        animation: 'pulse-pill-urgent 1s ease-in-out infinite',
-      };
-    case 'in-progress':
-      return {
-        background: 'var(--pulse-surface-2)',
-        border: '1px solid var(--pulse-text-4)',
-      };
-    case 'completed':
-      return {
-        background: 'var(--pulse-surface)',
-        border: '1px solid var(--pulse-border)',
-        opacity: 0.6,
-      };
-  }
+const CARTRIDGE_KINDS: CartridgeKind[] = ['voting', 'game', 'prompt', 'dilemma'];
+const isCartridgeKind = (k: PillKind): k is CartridgeKind =>
+  (CARTRIDGE_KINDS as PillKind[]).includes(k);
+
+/**
+ * Deterministic [0, 1500) ms offset from a stable string. Used as
+ * animation-delay so two concurrent active pills don't peak at the same
+ * frame. Stable across re-renders (same input → same delay), so the pulse
+ * doesn't jitter as state ticks.
+ */
+function heartbeatDelay(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) | 0;
+  return Math.abs(h) % 1500;
 }
 
 interface PillProps {
@@ -67,36 +50,92 @@ interface PillProps {
   cartridgeId?: string;
 }
 
+/**
+ * Pill — cartridge lifecycle indicator in the pill row.
+ *
+ * Visual model (per docs/reports/pulse-mockups/15-day-shape-pills.html v5):
+ *
+ *   upcoming     → solid 1px kind-color border at 40%, full opacity. The
+ *                  future is already coloured-in; not greyed out / disabled.
+ *   starting     → ignition one-shot then settles into the active styling.
+ *   needs-action → "active" in the design model: cartridge open, you haven't
+ *                  acted. Kind-color glow (24px @ 0.55) + breathing scale.
+ *   in-progress  → "acted": cartridge open, you've contributed. Kind border
+ *                  but NO glow, NO heartbeat. Verb microcopy (cast/placed/sent
+ *                  /chosen) marks "you did the thing"; meta still shows the
+ *                  countdown so you know when results land.
+ *   urgent       → kind glow dropped entirely; accent-pink ring carries the
+ *                  alarm alone (700ms shadow swing). Leading dot. Reads as a
+ *                  doorbell, not a louder hum.
+ *   completed    → unread = subtle kind-tint + pink dot affordance (no
+ *                  ambient glow — locked decision). read = mini, dim,
+ *                  icon-only.
+ */
 export function Pill({ pill, mini, onTap, buttonRef, unread, cartridgeId }: PillProps) {
+  // Boundary hero variant: render a separate component below — fully different
+  // shape (72px tall, two-line internal layout). Bail out early.
+  if (pill.kind === 'boundary' && pill.hero) {
+    return <BoundaryHeroPill pill={pill} buttonRef={buttonRef} onTap={onTap} />;
+  }
+
   const Icon = PILL_ICONS[pill.kind] || ChatCircleDots;
   const kindColor = PILL_COLORS[pill.kind] || 'var(--pulse-accent)';
-  const styles = lifecycleStyles(pill.lifecycle);
-  const showDot = pill.lifecycle === 'just-started' || pill.lifecycle === 'starting';
-  const showBadge = pill.lifecycle === 'needs-action' || pill.lifecycle === 'urgent';
-  const isActive = pill.lifecycle !== 'completed' && pill.lifecycle !== 'upcoming';
-  const isInProgress = pill.lifecycle === 'in-progress';
-  const isCompleted = pill.lifecycle === 'completed';
-  const isUnreadCompleted = isCompleted && !!unread;
   const reduce = useReducedMotion();
 
-  // Pill ignition: one-shot animation when transitioning from a pre-active
-  // lifecycle (upcoming/starting) into any active lifecycle (just-started,
-  // needs-action, in-progress, urgent). Broadened from "only → just-started"
-  // so voting/prompt/dilemma that land directly in needs-action also ignite.
-  // Pill landing: one-shot animation when any active lifecycle → completed.
-  const prevLifecycle = useRef(pill.lifecycle);
+  const isSocialWindow = !!pill.isSocialWindow;
+  const isBoundary = pill.kind === 'boundary';
+  const isCartridge = isCartridgeKind(pill.kind);
+
+  const isUpcoming = pill.lifecycle === 'upcoming';
+  const isActiveLifecycle = pill.lifecycle === 'needs-action' || pill.lifecycle === 'just-started' || pill.lifecycle === 'starting';
+  // Cartridges get the active heartbeat + kind glow ("demand attention").
+  // Social windows are long ambient open states — they should NOT pulse or
+  // strobe; user feedback (Apr 26) confirmed pulsing DMs/group chats are
+  // visually distracting since they can be open for hours.
+  const isActive = isActiveLifecycle && isCartridge;
+  const isActiveSocial = isActiveLifecycle && isSocialWindow;
+  // Acted only applies to cartridges. Social windows don't have an acted state.
+  const isActed = pill.lifecycle === 'in-progress' && isCartridge;
+  // Urgent only fires for cartridges (social windows / boundary skip it).
+  const isUrgent = pill.lifecycle === 'urgent' && isCartridge;
+  const isCompleted = pill.lifecycle === 'completed';
+  // Pink unread dot: any cartridge pill flagged unread (the seen/unseen
+  // contract, not strictly "completed"). Social windows skip it — they have
+  // no result, so there's nothing to call the player back to read.
+  const showUnreadDot = !!unread && isCartridge;
+  const isReadCompleted = isCompleted && !unread;
+
+  // Read-completed pills auto-mini (icon only) so the row stays scannable
+  // across a 7-hour day. The `mini` prop is still respected as an explicit
+  // override.
+  const renderMini = mini ?? isReadCompleted;
+
+  // Per-state styling. We keep the "what does this state look like" logic
+  // close to the rendering so it's easy to scan against the design mockup.
+  const stateStyle = computeStateStyle({
+    lifecycle: pill.lifecycle,
+    kindColor,
+    isUnreadCompleted: showUnreadDot,
+    isReadCompleted,
+    isBoundary,
+    isActiveSocial,
+  });
+
+  // Ignition (one-shot) when transitioning upcoming/starting → any active
+  // lifecycle. Landing (one-shot) when any active → completed.
+  const prevLifecycle = useRef<PillLifecycle>(pill.lifecycle);
   const [igniting, setIgniting] = useState(false);
   const [landing, setLanding] = useState(false);
   useEffect(() => {
     const prev = prevLifecycle.current;
     prevLifecycle.current = pill.lifecycle;
     const wasPreActive = prev === 'upcoming' || prev === 'starting';
-    const isNowActiveNonStarting =
+    const isNowActive =
       pill.lifecycle === 'just-started' ||
       pill.lifecycle === 'needs-action' ||
       pill.lifecycle === 'in-progress' ||
       pill.lifecycle === 'urgent';
-    if (wasPreActive && isNowActiveNonStarting) {
+    if (wasPreActive && isNowActive) {
       setIgniting(true);
       const t = setTimeout(() => setIgniting(false), 450);
       return () => clearTimeout(t);
@@ -108,139 +147,148 @@ export function Pill({ pill, mini, onTap, buttonRef, unread, cartridgeId }: Pill
     }
   }, [pill.lifecycle]);
 
-  // Priority: ignition > landing > ambient unread glow. They are
-  // mutually exclusive in time anyway (landing fires once into completed,
-  // then the ambient glow takes over while unread).
+  // Animation class precedence: ignition > landing > urgent shadow swing >
+  // boundary imminence. Completed-unread no longer carries an ambient glow —
+  // the pink dot does the "look at me" job (locked design decision).
+  // Boundary imminence (gold + pink layered shadow swing) is its own keyframe
+  // so the gold identity stays load-bearing — boundary is not a cartridge
+  // alarm, but it should feel "the day's ending soon" louder than calm.
+  const isBoundaryImminent = isBoundary && pill.lifecycle === 'urgent';
   const animationClass = igniting
     ? 'pulse-pill-ignition'
     : landing
       ? 'pulse-pill-landing'
-      : isUnreadCompleted
-        ? 'pulse-pill-completed-unread'
-        : undefined;
+      : isUrgent
+        ? 'pulse-pill-urgent'
+        : isBoundaryImminent
+          ? 'pulse-pill-boundary-imminent'
+          : undefined;
 
-  // Completed pills always keep kind-color identity — they hold results
-  // the user needs to be able to see and tap. The previous dim/gray
-  // archive state (opacity 0.6, surface bg, text-2 color) read as
-  // "disabled" even when unread. Two registers:
-  //
-  //   - Unread-completed ("results waiting"): strong kind-tinted bg,
-  //     near-solid border, static glow, full opacity.
-  //   - Read-completed ("viewable history"): subtle kind-tint, softer
-  //     border, calmer opacity — but still kind-owned, never gray.
-  //
-  // Both override the lifecycleStyles('completed') defaults.
-  const completedStyle: React.CSSProperties = isCompleted ? {
-    background: isUnreadCompleted
-      ? `color-mix(in oklch, ${kindColor} 28%, var(--pulse-surface))`
-      : `color-mix(in oklch, ${kindColor} 8%, var(--pulse-surface))`,
-    border: isUnreadCompleted
-      ? `1.5px solid color-mix(in oklch, ${kindColor} 80%, transparent)`
-      : `1px solid color-mix(in oklch, ${kindColor} 32%, transparent)`,
-    opacity: isUnreadCompleted ? 1 : 0.85,
-    ...(isUnreadCompleted ? {
-      // Static baseline glow so the kind signal reads even if the
-      // CSS ambient keyframe is fighting with framer-motion.
-      boxShadow: `0 0 10px color-mix(in oklch, ${kindColor} 40%, transparent)`,
-    } : {}),
-  } : {};
+  // Verb microcopy for the acted state. ACT_VERB is keyed by cartridge kind
+  // only — social windows don't have an acted phase.
+  const actVerb = isActed && isCartridgeKind(pill.kind) ? ACT_VERB[pill.kind] : null;
 
   return (
     <motion.button
       ref={buttonRef}
       className={animationClass}
       data-pill-cartridge-id={cartridgeId}
-      aria-label={mini ? pill.label : undefined}
+      data-pill-lifecycle={pill.lifecycle}
+      aria-label={renderMini ? pill.label : undefined}
       whileTap={PULSE_TAP.pill}
-      // Pointer-device hover lift. framer-motion only fires whileHover on
-      // pointer enter, so touch devices don't get a stuck-hover state on
-      // tap. Box-shadow is owned by the kind-themed static style (for
-      // unread-completed) or the CSS ambient keyframe — if hover animated
-      // box-shadow too, framer-motion would take over the property and
-      // kill whatever else was driving it.
       whileHover={reduce ? undefined : { y: -2 }}
       initial={{ opacity: 0, scale: 0.9 }}
-      animate={{ opacity: completedStyle.opacity ?? styles.opacity ?? 1, scale: 1 }}
+      animate={{ opacity: stateStyle.opacity ?? 1, scale: 1 }}
       transition={PULSE_SPRING.snappy}
       onClick={onTap}
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: mini ? 4 : 6,
-        padding: mini ? '4px 8px' : '6px 12px',
+        gap: renderMini ? 4 : 6,
+        padding: renderMini ? '4px 8px' : '6px 12px',
         borderRadius: 'var(--pulse-radius-xl)',
         cursor: 'pointer',
-        fontSize: mini ? 10 : 11,
+        fontSize: renderMini ? 10 : 11,
         fontWeight: 700,
         fontFamily: 'var(--po-font-body)',
-        // All completed pills (read or unread) keep kind color on text so
-        // they read as "results for a voting/game/prompt" — never gray.
-        color: isActive || isCompleted ? kindColor : 'var(--pulse-text-2)',
+        color: stateStyle.color,
         whiteSpace: 'nowrap',
         position: 'relative',
         letterSpacing: 0.3,
         textTransform: 'uppercase',
-        // --pill-glow drives both the landing burst and the ambient
-        // completed-unread keyframe via var() in pulse-theme.css.
-        ...((landing || isUnreadCompleted) ? { ['--pill-glow' as string]: kindColor } : {}),
-        ...styles,
-        ...(isActive ? {
-          background: `${kindColor}14`,
-          border: `1px solid ${kindColor}40`,
-        } : {}),
-        ...completedStyle,
+        background: stateStyle.background,
+        border: stateStyle.border,
+        boxShadow: stateStyle.boxShadow,
+        opacity: stateStyle.opacity,
+        // --pill-glow drives the landing burst keyframe (see pulse-theme.css)
+        ...((landing) ? { ['--pill-glow' as string]: kindColor } : {}),
       }}
     >
-      <motion.span
-        // In-progress heartbeat — subtle scale breath signals "something
-        // is happening inside this cartridge right now". Only runs while
-        // in-progress; other lifecycles keep the icon still.
-        animate={isInProgress && !reduce ? { scale: [1, 1.08, 1] } : { scale: 1 }}
-        transition={isInProgress && !reduce ? { duration: 2.4, repeat: Infinity, ease: 'easeInOut' } : { duration: 0 }}
-        style={{ display: 'inline-flex', flexShrink: 0 }}
+      {/* Inner wrapper carries the active-state heartbeat via CSS keyframe.
+          Putting it on a child element prevents conflict with the button's
+          framer-motion hover (translateY) and tap transforms — CSS keyframe
+          and inline transform on the same element overwrite each other.
+          A deterministic delay (hashed from cartridgeId) staggers concurrent
+          pulses so multiple actives don't strobe in lockstep. */}
+      <span
+        className={isActive ? 'pulse-pill-active-heartbeat' : undefined}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: renderMini ? 4 : 6,
+          color: 'inherit',
+          ...(isActive ? { animationDelay: `${heartbeatDelay(cartridgeId || pill.id)}ms` } : {}),
+        }}
       >
-        <Icon size={mini ? 14 : 16} weight="fill" />
-      </motion.span>
-      {!mini && <span>{pill.label}</span>}
-      {pill.progress && !mini && (
-        <span style={{ color: 'var(--pulse-text-2)', fontSize: 10 }}>{pill.progress}</span>
-      )}
-      {showDot && (
+      {/* Leading dot for urgent — the "doorbell" before the label. */}
+      {isUrgent && !renderMini && (
         <span
+          aria-hidden="true"
           style={{
             width: 6,
             height: 6,
             borderRadius: '50%',
-            background: kindColor,
-            boxShadow: `0 0 6px ${kindColor}`,
-            animation: 'pulse-breathe 2s ease-in-out infinite',
+            background: 'var(--pulse-accent)',
+            boxShadow: '0 0 8px var(--pulse-accent)',
             flexShrink: 0,
           }}
         />
       )}
-      {showBadge && (
-        <span
-          aria-hidden="true"
-          style={{
-            position: 'absolute',
-            top: -4,
-            right: -4,
-            width: 16,
-            height: 16,
-            borderRadius: '50%',
-            background: 'var(--pulse-accent)',
-            color: 'var(--pulse-on-accent)',
-            fontSize: 9,
-            fontWeight: 700,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          !
+
+      <span style={{ display: 'inline-flex', flexShrink: 0 }}>
+        <Icon size={renderMini ? 14 : 16} weight="fill" />
+      </span>
+
+      {!renderMini && (
+        <span style={{ color: 'inherit' }}>
+          {/* Voting label override in urgent state. Other kinds keep their label. */}
+          {isUrgent && pill.kind === 'voting' ? 'Vote now' : pill.label}
         </span>
       )}
-      {unread && cartridgeId && (
+
+      {/* Acted-state verb microcopy: "you did the thing" without a ✓ icon.
+          Renders BEFORE the meta countdown so it reads "Wager · placed · 5m left". */}
+      {actVerb && !renderMini && (
+        <span
+          style={{
+            color: kindColor,
+            fontSize: 10,
+            fontWeight: 700,
+            fontStyle: 'italic',
+            letterSpacing: 0.2,
+            textTransform: 'lowercase',
+          }}
+        >
+          · {actVerb}
+        </span>
+      )}
+
+      {/* Meta — pre-formatted by usePillStates, ticks live. e.g. "16:00",
+          "5m 00s left", "open · ends 12:00", "result". */}
+      {pill.meta && !renderMini && (
+        <span
+          style={{
+            color: 'inherit',
+            opacity: isActive || isUrgent ? 0.85 : 0.7,
+            fontWeight: 500,
+            fontSize: 10,
+            letterSpacing: 0.2,
+            textTransform: 'lowercase',
+          }}
+        >
+          · {pill.meta}
+        </span>
+      )}
+
+      {pill.progress && !renderMini && (
+        <span style={{ color: 'var(--pulse-text-2)', fontSize: 10 }}>{pill.progress}</span>
+      )}
+      </span>{/* /heartbeat wrapper */}
+
+      {/* Unread dot lives OUTSIDE the heartbeat wrapper so its position is
+          anchored to the button (relative parent), not the breathing inner
+          span. */}
+      {showUnreadDot && cartridgeId && (
         <span
           data-testid={`pill-unread-${cartridgeId}`}
           style={{
@@ -256,6 +304,248 @@ export function Pill({ pill, mini, onTap, buttonRef, unread, cartridgeId }: Pill
           }}
         />
       )}
+    </motion.button>
+  );
+}
+
+/**
+ * Compute background / border / box-shadow / color / opacity for a given
+ * lifecycle. Keeps the per-state visual contract co-located so it's
+ * straightforward to compare against the design mockup.
+ */
+function computeStateStyle(opts: {
+  lifecycle: PillLifecycle;
+  kindColor: string;
+  isUnreadCompleted: boolean;
+  isReadCompleted: boolean;
+  isBoundary?: boolean;
+  isActiveSocial?: boolean;
+}): {
+  background: string;
+  border: string;
+  boxShadow: string | undefined;
+  color: string;
+  opacity: number;
+} {
+  const { lifecycle, kindColor, isUnreadCompleted, isReadCompleted, isBoundary, isActiveSocial } = opts;
+
+  // Active social windows: kind tint + border, no outer glow. Calm "open"
+  // ambient state. The heartbeat class is also gated on isCartridge in the
+  // Pill render, so social windows don't breathe.
+  if (isActiveSocial) {
+    return {
+      background: `color-mix(in oklch, ${kindColor} 16%, var(--pulse-surface-2))`,
+      border: `1px solid color-mix(in oklch, ${kindColor} 50%, var(--pulse-border))`,
+      boxShadow: undefined,
+      color: kindColor,
+      opacity: 1,
+    };
+  }
+
+  // Boundary mini variant (during day) — gold gradient, gold border, label
+  // + meta. Hero variant has its own component (BoundaryHeroPill).
+  if (isBoundary) {
+    // Imminent escalation: when usePillStates flips the boundary's lifecycle
+    // to 'urgent' (< 5 min to day end), layer an accent-pink ring on top of
+    // the gold base. Gold reads "warm anchor"; pink reads "act now" — together
+    // they communicate "the day's ending and you should pay attention" without
+    // dropping gold identity (still a boundary, not a cartridge alarm).
+    const isImminent = lifecycle === 'urgent';
+    return {
+      background: isImminent
+        ? 'linear-gradient(180deg, color-mix(in oklch, var(--pulse-gold) 22%, transparent), color-mix(in oklch, var(--pulse-accent) 8%, transparent))'
+        : 'linear-gradient(180deg, color-mix(in oklch, var(--pulse-gold) 10%, transparent), transparent)',
+      border: isImminent ? `1.5px solid var(--pulse-gold)` : `1.5px solid var(--pulse-gold-soft)`,
+      boxShadow: isImminent
+        ? '0 0 22px color-mix(in oklch, var(--pulse-gold) 60%, transparent), 0 0 14px color-mix(in oklch, var(--pulse-accent) 40%, transparent)'
+        : undefined,
+      color: 'var(--pulse-gold)',
+      opacity: 1,
+    };
+  }
+
+  switch (lifecycle) {
+    case 'upcoming':
+      // Solid kind-color border at ~40% — "the future is already coloured-in".
+      // Full opacity, calm. No animation.
+      return {
+        background: 'transparent',
+        border: `1px solid color-mix(in oklch, ${kindColor} 40%, var(--pulse-border-2))`,
+        boxShadow: undefined,
+        color: 'var(--pulse-text-2)',
+        opacity: 1,
+      };
+
+    case 'starting':
+    case 'just-started':
+    case 'needs-action':
+      // "Active" in design terms: kind-color glow + heartbeat.
+      return {
+        background: `color-mix(in oklch, ${kindColor} 32%, var(--pulse-surface-2))`,
+        border: `1.5px solid ${kindColor}`,
+        boxShadow: `0 0 24px color-mix(in oklch, ${kindColor} 55%, transparent), inset 0 0 0 1px color-mix(in oklch, var(--pulse-text-1) 4%, transparent)`,
+        color: kindColor,
+        opacity: 1,
+      };
+
+    case 'in-progress':
+      // "Acted": kind border, NO glow, NO heartbeat. Calm with confirmation
+      // (the verb microcopy carries the meaning).
+      return {
+        background: `color-mix(in oklch, ${kindColor} 12%, var(--pulse-surface-2))`,
+        border: `1px solid color-mix(in oklch, ${kindColor} 55%, var(--pulse-border))`,
+        boxShadow: undefined,
+        color: kindColor,
+        opacity: 1,
+      };
+
+    case 'urgent':
+      // Kind glow DROPPED. Accent-pink ring carries the alarm alone.
+      // The keyframe (pulse-pill-urgent) drives the box-shadow swing.
+      return {
+        background: `color-mix(in oklch, var(--pulse-accent) 12%, var(--pulse-surface-2))`,
+        border: `1.5px solid var(--pulse-accent)`,
+        boxShadow: undefined, // owned by the keyframe
+        color: 'var(--pulse-accent)',
+        opacity: 1,
+      };
+
+    case 'completed': {
+      if (isUnreadCompleted) {
+        // Subtle kind-tint, no ambient glow. The pink unread dot does the
+        // notification job (locked decision).
+        return {
+          background: `color-mix(in oklch, ${kindColor} 14%, var(--pulse-surface-2))`,
+          border: `1px solid color-mix(in oklch, ${kindColor} 38%, var(--pulse-border))`,
+          boxShadow: undefined,
+          color: kindColor,
+          opacity: 1,
+        };
+      }
+      // Read: settles. Mini-mode shrinks the row footprint elsewhere.
+      return {
+        background: 'var(--pulse-surface-2)',
+        border: '1px solid var(--pulse-border)',
+        boxShadow: undefined,
+        color: 'var(--pulse-text-3)',
+        opacity: isReadCompleted ? 0.55 : 1,
+      };
+    }
+  }
+}
+
+/**
+ * BoundaryHeroPill — pregame / night anchor. Taller (56px) than a normal pill,
+ * two-line internal layout: small-caps eyebrow over big body number, with an
+ * optional relative countdown ("in 5m 30s") next to the body. Gold-rich
+ * background with breathing glow when imminent (< 5 min to start).
+ *
+ * The hero variant is its own component because it diverges from the
+ * standard pill geometry — co-locating the styling with the regular Pill
+ * branch would balloon that function.
+ */
+function BoundaryHeroPill({
+  pill,
+  buttonRef,
+  onTap,
+}: {
+  pill: PillState;
+  buttonRef?: (el: HTMLButtonElement | null) => void;
+  onTap?: () => void;
+}) {
+  const reduce = useReducedMotion();
+  const tickNow = useNowTick(1000);
+  if (!pill.hero) return null;
+
+  // Imminent: < 5 min to start (start of next phase). Live-tick re-renders
+  // pull this calc forward each second.
+  const imminentMs = 5 * 60 * 1000;
+  const remainingMs = pill.startTime !== undefined ? pill.startTime - tickNow : Infinity;
+  const isImminent = remainingMs > 0 && remainingMs < imminentMs;
+
+  return (
+    <motion.button
+      ref={buttonRef}
+      onClick={onTap}
+      data-pill-cartridge-id={pill.id}
+      data-pill-lifecycle={pill.lifecycle}
+      data-pill-hero="true"
+      whileTap={PULSE_TAP.pill}
+      whileHover={reduce ? undefined : { y: -2 }}
+      initial={{ opacity: 0, scale: 0.92 }}
+      animate={
+        isImminent && !reduce
+          ? {
+              opacity: 1,
+              scale: 1,
+              boxShadow: [
+                '0 0 32px color-mix(in oklch, var(--pulse-gold) 30%, transparent), inset 0 0 0 1px color-mix(in oklch, var(--pulse-gold) 18%, transparent)',
+                '0 0 56px color-mix(in oklch, var(--pulse-gold) 65%, transparent), inset 0 0 0 1px color-mix(in oklch, var(--pulse-gold) 32%, transparent)',
+                '0 0 32px color-mix(in oklch, var(--pulse-gold) 30%, transparent), inset 0 0 0 1px color-mix(in oklch, var(--pulse-gold) 18%, transparent)',
+              ],
+            }
+          : { opacity: 1, scale: 1 }
+      }
+      transition={
+        isImminent && !reduce
+          ? { duration: 1.6, repeat: Infinity, ease: 'easeInOut' }
+          : PULSE_SPRING.snappy
+      }
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        height: 56,
+        padding: '0 22px',
+        borderRadius: 'var(--pulse-radius-xl)',
+        cursor: 'pointer',
+        background:
+          'radial-gradient(ellipse at top, color-mix(in oklch, var(--pulse-gold) 18%, transparent), color-mix(in oklch, var(--pulse-gold) 4%, transparent) 70%), var(--pulse-surface-2)',
+        border: `1.5px solid var(--pulse-gold)`,
+        boxShadow: isImminent
+          ? undefined
+          : '0 0 32px color-mix(in oklch, var(--pulse-gold) 30%, transparent), inset 0 0 0 1px color-mix(in oklch, var(--pulse-gold) 18%, transparent)',
+        color: 'var(--pulse-gold)',
+        flexShrink: 0,
+      }}
+    >
+      <span style={{ display: 'inline-flex', flexShrink: 0, filter: 'drop-shadow(0 0 8px color-mix(in oklch, var(--pulse-gold) 55%, transparent))' }}>
+        <Clock size={22} weight="fill" />
+      </span>
+      <span style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 0, lineHeight: 1 }}>
+        <span
+          style={{
+            fontFamily: 'var(--po-font-display, var(--po-font-body))',
+            fontSize: 10,
+            fontWeight: 900,
+            letterSpacing: 0.28 * 10,
+            textTransform: 'uppercase',
+            color: 'color-mix(in oklch, var(--pulse-gold) 72%, transparent)',
+            marginBottom: 5,
+          }}
+        >
+          {pill.hero.eyebrow}
+        </span>
+        <span
+          style={{
+            fontFamily: 'var(--po-font-display, var(--po-font-body))',
+            fontSize: 22,
+            fontWeight: 700,
+            letterSpacing: -0.02 * 22,
+            color: 'var(--pulse-gold)',
+            display: 'inline-flex',
+            alignItems: 'baseline',
+            gap: 8,
+          }}
+        >
+          {pill.hero.body}
+          {pill.hero.rel && (
+            <span style={{ fontSize: 12, fontWeight: 600, letterSpacing: 0.4, color: 'color-mix(in oklch, var(--pulse-gold) 72%, transparent)' }}>
+              in {pill.hero.rel}
+            </span>
+          )}
+        </span>
+      </span>
     </motion.button>
   );
 }

--- a/apps/client/src/shells/pulse/components/PulseBar.tsx
+++ b/apps/client/src/shells/pulse/components/PulseBar.tsx
@@ -1,12 +1,18 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useGameStore, selectCartridgeUnread } from '../../../store/useGameStore';
-import { usePillStates, type PillState } from '../hooks/usePillStates';
+import { usePillStates, useDayPhase, type PillState, type CartridgeKind } from '../hooks/usePillStates';
+
+const CARTRIDGE_KINDS: CartridgeKind[] = ['voting', 'game', 'prompt', 'dilemma'];
+const isCartridgePill = (p: PillState): p is PillState & { kind: CartridgeKind } =>
+  (CARTRIDGE_KINDS as PillState['kind'][]).includes(p.kind);
 import { useHasOverflow } from '../hooks/useHasOverflow';
 import { PULSE_Z } from '../zIndex';
 import { runViewTransition, supportsViewTransitions, prefersReducedMotion } from '../viewTransitions';
 import { usePillOrigin } from './cartridge-overlay/usePillOrigin';
 import { Pill } from './Pill';
+import { NowLine } from './NowLine';
+import { EdgePin } from './EdgePin';
 
 /**
  * PulseBar shows cartridge pills in chronological order.
@@ -23,7 +29,14 @@ import { Pill } from './Pill';
  * collide with the transient `active-pill` tag used for tap-to-open.
  */
 export function PulseBar() {
-  const pills = usePillStates();
+  const allPills = usePillStates();
+  const phase = useDayPhase();
+  // Pregame: only the boundary anchor renders. Cartridge / social-window
+  // pills stay in the data layer (so CartridgeOverlay's id lookup still
+  // resolves a deep-linked cartridge during pregame), but they don't show
+  // in the row — consistent with the dynamic-day reality where the
+  // manifest may not be built yet.
+  const pills = phase === 'pregame' ? allPills.filter((p) => p.kind === 'boundary') : allPills;
   const focusCartridge = useGameStore(s => s.focusCartridge);
   const markCartridgeSeen = useGameStore(s => s.markCartridgeSeen);
   const dayIndex = useGameStore(s => s.dayIndex);
@@ -35,12 +48,27 @@ export function PulseBar() {
   useGameStore(s => s.lastSeenCartridge);
   const { set: setPillOrigin } = usePillOrigin();
   const pillRefs = useRef<Record<string, HTMLButtonElement | null>>({});
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Mirror scrollRef into state so EdgePin re-renders when the row mounts
+  // (refs aren't reactive — passing scrollRef.current as a prop on the first
+  // render passes null and never updates).
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
   const overflow = useHasOverflow(scrollRef);
 
   if (pills.length === 0) return null;
 
   const handleTap = (pill: PillState) => {
+    // Social windows (DMs, group chat) and boundary pills don't open the
+    // cartridge overlay. Wiring for tap-to-open-DM-panel / tap-to-show-day-
+    // shape-detail is a follow-up; for now, no-op on non-cartridge taps so
+    // the row still receives the click without crashing focusCartridge's
+    // CartridgeKind contract.
+    if (!isCartridgePill(pill)) {
+      // TODO(pulse-day-shape): wire DM/group-chat pill taps → DM panel /
+      // group-chat opener; boundary tap → day-shape detail sheet.
+      return;
+    }
+
     const el = pillRefs.current[pill.id];
     const cartridgeId = pillToCartridgeId(pill, dayIndex);
     const vtActive = supportsViewTransitions() && !prefersReducedMotion();
@@ -74,33 +102,44 @@ export function PulseBar() {
         background: 'var(--pulse-surface)',
       }}
     >
-      <div
-        ref={scrollRef}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-          padding: '6px 12px',
-          height: 48,
-          overflowX: 'auto',
-          overflowY: 'hidden',
-          scrollbarWidth: 'none',
-        }}
-      >
-        {pills.map(pill => {
-          const cartridgeId = pillToCartridgeId(pill, dayIndex);
-          const unread = selectCartridgeUnread(useGameStore.getState(), cartridgeId);
-          return (
-            <Pill
-              key={pill.id}
-              pill={pill}
-              cartridgeId={cartridgeId}
-              unread={unread}
-              onTap={() => handleTap(pill)}
-              buttonRef={(el) => { pillRefs.current[pill.id] = el; }}
-            />
-          );
-        })}
+      <NowLine pills={pills} />
+      <div style={{ position: 'relative' }}>
+        <div
+          ref={(el) => {
+            scrollRef.current = el;
+            setScrollEl(el);
+          }}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '6px 12px',
+            height: 64,
+            overflowX: 'auto',
+            overflowY: 'hidden',
+            scrollbarWidth: 'none',
+          }}
+        >
+          {pills.map(pill => {
+            const cartridgeId = pillToCartridgeId(pill, dayIndex);
+            const unread = selectCartridgeUnread(useGameStore.getState(), cartridgeId);
+            return (
+              <Pill
+                key={pill.id}
+                pill={pill}
+                cartridgeId={cartridgeId}
+                unread={unread}
+                onTap={() => handleTap(pill)}
+                buttonRef={(el) => { pillRefs.current[pill.id] = el; }}
+              />
+            );
+          })}
+        </div>
+        <EdgePin
+          scrollContainer={scrollEl}
+          pills={pills}
+          pillNodes={pillRefs.current}
+        />
       </div>
       <EdgeFade side="left" visible={overflow.left} bg="var(--pulse-surface)" />
       <EdgeFade side="right" visible={overflow.right} bg="var(--pulse-surface)" />

--- a/apps/client/src/shells/pulse/components/VoteFloatingChip.tsx
+++ b/apps/client/src/shells/pulse/components/VoteFloatingChip.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { useGameStore } from '../../../store/useGameStore';
+import { PULSE_SPRING, PULSE_TAP } from '../springs';
+
+/**
+ * VoteFloatingChip — pink chip that docks above the chat input while voting
+ * is open. Dramatizes a central game mechanic outside the pill row, since
+ * voting always lives at the right edge of the row and risks scrolling
+ * off-screen on small phones.
+ *
+ * Two states:
+ *   - default: "Tap to vote · MM:SS" (or "Vote cast · MM:SS" once player has
+ *     voted), gentle bob, kind-pink fill
+ *   - urgent:  faster bob (900ms), bolder shadow swing (700ms), brighter
+ *     pink fill, slightly larger padding/font
+ *
+ * Wiring (TODO when integrating into PulseShell):
+ *   <div style={{ position: 'relative' }}>
+ *     <VoteFloatingChip />
+ *     <ChatInput />
+ *   </div>
+ *
+ * The chip absolutely positions itself above its containing block via
+ * bottom: calc(100% + 10px). Place it in a parent that wraps the chat
+ * input so the chip sits above it.
+ */
+
+const URGENT_THRESHOLD_MS = 5 * 60 * 1000;
+
+interface VoteFloatingChipProps {
+  /** Override Date.now() for tests / Storybook. */
+  now?: number;
+  /** Tap callback — wire to focus the voting cartridge. */
+  onTap?: () => void;
+}
+
+export function VoteFloatingChip({ now: nowProp, onTap }: VoteFloatingChipProps) {
+  const voting = useGameStore((s) => s.activeVotingCartridge);
+  const playerId = useGameStore((s) => s.playerId);
+  const reduce = useReducedMotion();
+
+  // Live ticking clock so the countdown updates each second. We sample once
+  // per second; framer-motion handles the visual breathing.
+  const [tick, setTick] = useState(() => nowProp ?? Date.now());
+  useEffect(() => {
+    if (nowProp !== undefined) return;
+    const id = window.setInterval(() => setTick(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [nowProp]);
+  const now = nowProp ?? tick;
+
+  // Debug demo path: ?force-urgent=voting (stashed by App.tsx into
+  // sessionStorage). Synthesizes the urgent variant so the visual is
+  // testable without timing a real close window.
+  const forced = typeof window !== 'undefined' && sessionStorage.getItem('po-force-urgent') === 'voting';
+
+  if (!voting && !forced) return null;
+  // Closed: REVEAL/WINNER means voting cartridge has tallied; chip should
+  // not be present (unless forced for demo).
+  if (voting && (voting.phase === 'REVEAL' || voting.phase === 'WINNER') && !forced) return null;
+
+  const playerActed = voting && playerId ? Boolean(voting.votes?.[playerId]) : false;
+
+  // closeAt may not be exposed on every voting projection. When absent, fall
+  // back to a generic "open" message — no countdown, no urgency.
+  const closeAt = forced
+    ? now + 4 * 60 * 1000
+    : ((voting as any)?.closeAt as number | undefined);
+  const remainingMs = closeAt !== undefined ? closeAt - now : null;
+  const isUrgent =
+    forced ||
+    (remainingMs !== null && remainingMs > 0 && remainingMs < URGENT_THRESHOLD_MS && !playerActed);
+
+  const text = (() => {
+    if (playerActed) {
+      return remainingMs !== null && remainingMs > 0
+        ? `Vote cast · ${formatCountdown(remainingMs)}`
+        : 'Vote cast';
+    }
+    if (isUrgent && remainingMs !== null) return `Vote closing · ${formatCountdown(remainingMs)}`;
+    if (remainingMs !== null && remainingMs > 0) return `Tap to vote · ${formatCountdown(remainingMs)}`;
+    return 'Tap to vote';
+  })();
+
+  return (
+    <motion.button
+      data-testid="pulse-vote-chip"
+      data-urgent={isUrgent ? 'true' : undefined}
+      onClick={onTap}
+      whileTap={PULSE_TAP.pill}
+      animate={
+        reduce
+          ? { y: 0 }
+          : isUrgent
+            ? { y: [-3, 2, -3], scale: [1, 1.04, 1] }
+            : { y: [-3, 0, -3], scale: 1 }
+      }
+      transition={
+        reduce
+          ? { duration: 0 }
+          : isUrgent
+            ? { duration: 0.9, repeat: Infinity, ease: 'easeInOut' }
+            : { duration: 2.4, repeat: Infinity, ease: 'easeInOut' }
+      }
+      initial={{ opacity: 0, scale: 0.92 }}
+      style={{
+        position: 'absolute',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        bottom: 'calc(100% + 10px)',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: isUrgent ? '12px 18px' : '10px 16px',
+        background: isUrgent ? 'color-mix(in oklch, var(--pulse-accent) 90%, white)' : 'var(--pulse-accent)',
+        color: 'var(--pulse-on-accent, #1a0710)',
+        fontFamily: 'var(--po-font-display, var(--po-font-body))',
+        fontWeight: 800,
+        fontSize: isUrgent ? 14 : 13,
+        letterSpacing: 0.3,
+        borderRadius: 'var(--pulse-radius-xl, 100px)',
+        border: 'none',
+        cursor: 'pointer',
+        boxShadow: isUrgent
+          ? '0 14px 36px color-mix(in oklch, var(--pulse-accent) 85%, transparent), 0 0 0 10px color-mix(in oklch, var(--pulse-accent) 30%, transparent)'
+          : '0 8px 24px color-mix(in oklch, var(--pulse-accent) 45%, transparent), 0 0 0 4px color-mix(in oklch, var(--pulse-accent) 16%, transparent)',
+        zIndex: 50,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: isUrgent ? 8 : 7,
+          height: isUrgent ? 8 : 7,
+          borderRadius: '50%',
+          background: 'var(--pulse-on-accent, #1a0710)',
+          boxShadow: isUrgent ? '0 0 0 2px rgba(26,7,16,0.4)' : undefined,
+        }}
+      />
+      {text}
+    </motion.button>
+  );
+}
+
+function formatCountdown(ms: number): string {
+  const m = Math.max(0, ms / 60_000);
+  const mInt = Math.floor(m);
+  const sInt = Math.max(0, Math.floor((m - mInt) * 60));
+  return `${mInt}m ${String(sInt).padStart(2, '0')}s`;
+}

--- a/apps/client/src/shells/pulse/components/__tests__/PulseBarUnread.test.tsx
+++ b/apps/client/src/shells/pulse/components/__tests__/PulseBarUnread.test.tsx
@@ -33,8 +33,15 @@ describe('PulseBar — unread dot', () => {
   });
 
   it('marks the cartridge seen and focuses it when the pill is tapped', () => {
-    render(<PulseBar />);
-    fireEvent.click(screen.getByRole('button'));
+    const { container } = render(<PulseBar />);
+    // Multiple pill buttons may render now (cartridges + boundary anchor).
+    // Target the voting pill specifically via the data attribute the
+    // component sets.
+    const votingPill = container.querySelector(
+      '[data-pill-cartridge-id="voting-3-MAJORITY"]',
+    ) as HTMLButtonElement;
+    expect(votingPill).not.toBeNull();
+    fireEvent.click(votingPill);
     const state = useGameStore.getState();
     expect(state.lastSeenCartridge['voting-3-MAJORITY']).toBeDefined();
     expect(state.focusedCartridge).toEqual({

--- a/apps/client/src/shells/pulse/components/caststrip/ShareChip.tsx
+++ b/apps/client/src/shells/pulse/components/caststrip/ShareChip.tsx
@@ -79,9 +79,13 @@ function ShareChipInner({ gameCode }: Props) {
   const [success, setSuccess] = useState(false);
 
   const handleTap = useCallback(async () => {
+    // Personal voice — the player IS the cast, not a marketer. iOS share-sheet
+    // appends the URL separately, so we don't repeat the code in the text.
+    // Recipients still see the verb-stack mantra via the unfurl card on /j/CODE
+    // (set in apps/lobby/app/j/[code]/page.tsx generateMetadata).
     const shareData = {
       title: 'Pecking Order',
-      text: `I'm in a game on Pecking Order — you're cast. Code ${gameCode.toUpperCase()}`,
+      text: `You're cast in my Pecking Order game — tap in.`,
       url: shareUrl,
     };
 

--- a/apps/client/src/shells/pulse/components/input/PulseInput.tsx
+++ b/apps/client/src/shells/pulse/components/input/PulseInput.tsx
@@ -17,6 +17,7 @@ import { WhisperMode } from './WhisperMode';
 import { ReplyBar } from './ReplyBar';
 import { MentionAutocomplete } from './MentionAutocomplete';
 import { SendButton } from './SendButton';
+import { VoteFloatingChip } from '../VoteFloatingChip';
 import { DayPhases } from '@pecking-order/shared-types';
 import type { ChatMessage } from '@pecking-order/shared-types';
 
@@ -26,6 +27,9 @@ export function PulseInput() {
   const mainCapabilities = useGameStore(s => s.channels?.['MAIN']?.capabilities);
   const groupChatOpen = useGameStore(s => s.groupChatOpen);
   const dmsOpen = useGameStore(s => s.dmsOpen);
+  const focusCartridge = useGameStore(s => s.focusCartridge);
+  const dayIndex = useGameStore(s => s.dayIndex);
+  const voting = useGameStore(s => s.activeVotingCartridge);
   const [text, setText] = useState('');
   const [replyTo, setReplyTo] = useState<ChatMessage | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -275,7 +279,19 @@ export function PulseInput() {
               phase={phase}
             />
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--pulse-space-sm)', padding: 'var(--pulse-space-md) var(--pulse-space-md)' }}>
+          <div style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 'var(--pulse-space-sm)', padding: 'var(--pulse-space-md) var(--pulse-space-md)' }}>
+            {/* Floating vote chip — special case for voting since voting is
+                the central game mechanic and always lives at the right edge
+                of the pill row (risks scrolling off on small phones). The
+                chip absolute-positions itself above the input via
+                bottom: calc(100% + 10px). */}
+            <VoteFloatingChip
+              onTap={() => {
+                if (!voting) return;
+                const typeKey = (voting as any).mechanism || (voting as any).voteType || 'UNKNOWN';
+                focusCartridge(`voting-${dayIndex}-${typeKey}`, 'voting', 'manual');
+              }}
+            />
             <input
               ref={inputRef}
               value={text}

--- a/apps/client/src/shells/pulse/hooks/__tests__/usePillStates.test.ts
+++ b/apps/client/src/shells/pulse/hooks/__tests__/usePillStates.test.ts
@@ -34,9 +34,10 @@ describe('usePillStates — ADR-128 gap detection', () => {
       } as any,
     });
     const { result } = renderHook(() => usePillStates());
-    expect(result.current).toHaveLength(1);
-    expect(result.current[0].lifecycle).toBe('starting');
-    expect(result.current[0].kind).toBe('voting');
+    const cartridgePills = result.current.filter(p => p.kind !== 'boundary');
+    expect(cartridgePills).toHaveLength(1);
+    expect(cartridgePills[0].lifecycle).toBe('starting');
+    expect(cartridgePills[0].kind).toBe('voting');
   });
 
   it('emits upcoming pill when timeline event is still in the future', () => {
@@ -51,8 +52,9 @@ describe('usePillStates — ADR-128 gap detection', () => {
       } as any,
     });
     const { result } = renderHook(() => usePillStates());
-    expect(result.current).toHaveLength(1);
-    expect(result.current[0].lifecycle).toBe('upcoming');
+    const cartridgePills = result.current.filter(p => p.kind !== 'boundary');
+    expect(cartridgePills).toHaveLength(1);
+    expect(cartridgePills[0].lifecycle).toBe('upcoming');
   });
 
   it('suppresses starting when the active slot is populated', () => {
@@ -182,11 +184,12 @@ describe('usePillStates — upcoming pill labels from manifest day fields', () =
       } as any,
     });
     const { result } = renderHook(() => usePillStates());
-    expect(result.current).toHaveLength(1);
-    expect(result.current[0].lifecycle).toBe('upcoming');
-    expect(result.current[0].cartridgeData).toEqual({ promptType: 'WOULD_YOU_RATHER' });
+    const cartridgePills = result.current.filter(p => p.kind !== 'boundary');
+    expect(cartridgePills).toHaveLength(1);
+    expect(cartridgePills[0].lifecycle).toBe('upcoming');
+    expect(cartridgePills[0].cartridgeData).toEqual({ promptType: 'WOULD_YOU_RATHER' });
     // Label should be CARTRIDGE_INFO['WOULD_YOU_RATHER'].displayName, not 'Activity'
-    expect(result.current[0].label).not.toBe('Activity');
+    expect(cartridgePills[0].label).not.toBe('Activity');
   });
 
   it('renders a specific label for an upcoming Vote when the day has voteType', () => {
@@ -200,8 +203,9 @@ describe('usePillStates — upcoming pill labels from manifest day fields', () =
       } as any,
     });
     const { result } = renderHook(() => usePillStates());
-    expect(result.current[0].cartridgeData).toEqual({ voteType: 'EXECUTIONER' });
-    expect(result.current[0].label).not.toBe('Vote');
+    const votingPill = result.current.find(p => p.kind === 'voting')!;
+    expect(votingPill.cartridgeData).toEqual({ voteType: 'EXECUTIONER' });
+    expect(votingPill.label).not.toBe('Vote');
   });
 
   it('falls back to generic label when day field is NONE', () => {
@@ -215,8 +219,9 @@ describe('usePillStates — upcoming pill labels from manifest day fields', () =
       } as any,
     });
     const { result } = renderHook(() => usePillStates());
-    expect(result.current[0].cartridgeData).toBeUndefined();
-    expect(result.current[0].label).toBe('Activity');
+    const promptPill = result.current.find(p => p.kind === 'prompt')!;
+    expect(promptPill.cartridgeData).toBeUndefined();
+    expect(promptPill.label).toBe('Activity');
   });
 });
 

--- a/apps/client/src/shells/pulse/hooks/useNowTick.ts
+++ b/apps/client/src/shells/pulse/hooks/useNowTick.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useNowTick — re-renders the consumer every `intervalMs` (default 1s) and
+ * returns the current `Date.now()`. Used by usePillStates / NowLine /
+ * VoteFloatingChip so countdown copy ticks live without requiring store
+ * mutations to drive the re-render.
+ *
+ * Cheap: a single setInterval per consumer. Pause via passing `enabled=false`
+ * (covers prefers-reduced-motion + hidden-tab cases — callers can pair with
+ * `document.visibilityState` if they want).
+ */
+export function useNowTick(intervalMs: number = 1000, enabled: boolean = true): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!enabled) return;
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs, enabled]);
+  return now;
+}

--- a/apps/client/src/shells/pulse/hooks/usePillStates.ts
+++ b/apps/client/src/shells/pulse/hooks/usePillStates.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { CARTRIDGE_INFO } from '@pecking-order/shared-types';
 import { useGameStore } from '../../../store/useGameStore';
+import { useNowTick } from './useNowTick';
 
 function prettyLabel(typeKey: string | undefined, fallback: string): string {
   if (!typeKey) return fallback;
@@ -9,18 +10,67 @@ function prettyLabel(typeKey: string | undefined, fallback: string): string {
 
 export type PillLifecycle = 'upcoming' | 'starting' | 'just-started' | 'needs-action' | 'urgent' | 'in-progress' | 'completed';
 
+/**
+ * Pill kinds:
+ *   Cartridges (have act + reveal phases): voting | game | prompt | dilemma
+ *   Social windows (timeline-driven open/close, no acting):  dms | group
+ *   Boundary anchor (gold; pregame / day-end / night):       boundary
+ */
+export type PillKind = 'voting' | 'game' | 'prompt' | 'dilemma' | 'dms' | 'group' | 'boundary';
+
+export type CartridgeKind = 'voting' | 'game' | 'prompt' | 'dilemma';
+
 export interface PillState {
   id: string;
-  kind: 'voting' | 'game' | 'prompt' | 'dilemma';
+  kind: PillKind;
   label: string;
   lifecycle: PillLifecycle;
   timeRemaining?: number;
   progress?: string;
   playerActed?: boolean;
   cartridgeData?: any;
+
+  /**
+   * Pre-formatted meta string rendered after the label, e.g. "16:00",
+   * "5m 00s left", "open · ends 12:00", "result". Computed in usePillStates
+   * so Pill.tsx is a dumb renderer; recomputes on every useNowTick tick.
+   */
+  meta?: string;
+
+  /** True for dms/group pills. Pill.tsx skips ACT_VERB / dot / urgent for these. */
+  isSocialWindow?: boolean;
+
+  /** Wall-clock window times (ms epoch) for sortable chronology + meta copy. */
+  startTime?: number;
+  endTime?: number;
+
+  /**
+   * Hero variant payload for boundary pills in pregame / night. When present,
+   * Pill.tsx renders a 72px two-line layout (eyebrow + body + rel countdown)
+   * instead of the normal label/meta line.
+   */
+  hero?: { eyebrow: string; body: string; rel?: string };
 }
 
-const ACTION_TO_KIND: Record<string, PillState['kind']> = {
+/**
+ * Past-tense verb for the player's own action, shown in the in-progress
+ * (acted) lifecycle as microcopy after the label. Universal per cartridge
+ * kind so the acted state always reads as "you did X" — distinct from the
+ * completed state's universal noun "result" which describes the all-player
+ * artifact.
+ *
+ * The verb-vs-noun split is intentional: acted = verb (your action),
+ * completed = noun (the artifact). They stop competing because they refer
+ * to different concepts.
+ */
+export const ACT_VERB: Record<CartridgeKind, string> = {
+  voting: 'cast',
+  game: 'placed',
+  prompt: 'sent',
+  dilemma: 'chosen',
+};
+
+const ACTION_TO_KIND: Record<string, CartridgeKind> = {
   OPEN_VOTING: 'voting',
   START_GAME: 'game',
   START_ACTIVITY: 'prompt',
@@ -34,8 +84,83 @@ const ACTION_LABELS: Record<string, string> = {
   START_DILEMMA: 'Dilemma',
 };
 
+/** Pair OPEN/CLOSE timeline actions for social-window pills. */
+const SOCIAL_OPEN_ACTIONS: Record<string, { kind: 'dms' | 'group'; closeAction: string; label: string }> = {
+  OPEN_DMS:        { kind: 'dms',   closeAction: 'CLOSE_DMS',        label: 'DMs' },
+  OPEN_GROUP_CHAT: { kind: 'group', closeAction: 'CLOSE_GROUP_CHAT', label: 'Group' },
+};
+
+/** Cartridge kind → close timeline action (for urgent-on-imminent-close). */
+const CLOSE_ACTION_FOR_CARTRIDGE: Record<CartridgeKind, string> = {
+  voting: 'CLOSE_VOTING',
+  game: 'END_GAME',
+  prompt: 'END_ACTIVITY',
+  dilemma: 'END_DILEMMA',
+};
+
+/** Threshold (ms) before close-time at which a not-yet-acted cartridge flips to urgent. */
+const URGENT_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * Captured at module load — App.tsx normalizes the URL to /game/CODE on
+ * load (drops query string), so reading window.location.search inside the
+ * hook would always be empty by the time it runs. Capturing once at module
+ * eval time wins the race with the URL strip.
+ */
+/**
+ * Read the force-urgent debug param. App.tsx stashes the URL param into
+ * sessionStorage on game-route entry (before the URL strip), so we read
+ * from there. Returns null when not set.
+ */
+function readForceUrgent(): CartridgeKind | null {
+  if (typeof window === 'undefined') return null;
+  // Check sessionStorage first (survives the App's URL strip), then live URL
+  // for cases where the strip hasn't happened yet (e.g., showcase route).
+  const stash = sessionStorage.getItem('po-force-urgent');
+  const live = new URLSearchParams(window.location.search).get('force-urgent');
+  const v = stash || live;
+  if (!v) return null;
+  return (v === 'voting' || v === 'game' || v === 'prompt' || v === 'dilemma') ? v : null;
+}
+
+export type DayPhase = 'pregame' | 'day' | 'night';
+
+/**
+ * Detect day phase from manifest's day timeline. Pregame: before first event.
+ * Night: after END_DAY (or last timeline event). Day: between.
+ *
+ * Falls back to 'day' when there's no manifest or no timeline (DYNAMIC days
+ * without a built manifest, missing scheduling, etc.) — safer to show
+ * cartridges than to false-positive-hide them.
+ */
+export function derivePhase(manifest: any, dayIndex: number, now: number): DayPhase {
+  const day = manifest?.days?.[dayIndex - 1] ?? manifest?.days?.[dayIndex];
+  if (!day?.timeline || manifest?.scheduling !== 'PRE_SCHEDULED') return 'day';
+  const tl = (day.timeline as any[]).filter((e) => e.time?.includes('T'));
+  if (tl.length === 0) return 'day';
+  const times = tl.map((e) => new Date(e.time).getTime());
+  const start = Math.min(...times);
+  const endDay = tl.find((e) => e.action === 'END_DAY');
+  const end = endDay ? new Date(endDay.time).getTime() : Math.max(...times);
+  if (now < start) return 'pregame';
+  if (now >= end) return 'night';
+  return 'day';
+}
+
+/**
+ * Hook variant of derivePhase. Re-evaluates on store mutations only —
+ * callers that need second-level granularity should pair this with their
+ * own setInterval-driven re-render. (Most consumers are fine with the
+ * mutation cadence + the natural re-renders on pill state changes.)
+ */
+export function useDayPhase(): DayPhase {
+  const manifest = useGameStore((s) => s.manifest);
+  const dayIndex = useGameStore((s) => s.dayIndex);
+  return useMemo(() => derivePhase(manifest, dayIndex, Date.now()), [manifest, dayIndex]);
+}
+
 /** Pull the day-level type field for a given action kind from the manifest day. */
-function dayTypeKeyFor(kind: PillState['kind'], day: any): string | undefined {
+function dayTypeKeyFor(kind: CartridgeKind, day: any): string | undefined {
   switch (kind) {
     case 'voting': return day?.voteType && day.voteType !== 'NONE' ? day.voteType : undefined;
     case 'game': return day?.gameType && day.gameType !== 'NONE' ? day.gameType : undefined;
@@ -46,7 +171,7 @@ function dayTypeKeyFor(kind: PillState['kind'], day: any): string | undefined {
 
 /** Build a minimal cartridgeData object for upcoming/starting pills so the
  *  overlay's info splash can render the specific CARTRIDGE_INFO entry. */
-function upcomingCartridgeData(kind: PillState['kind'], typeKey: string | undefined): any {
+function upcomingCartridgeData(kind: CartridgeKind, typeKey: string | undefined): any {
   if (!typeKey) return undefined;
   switch (kind) {
     case 'voting': return { voteType: typeKey };
@@ -57,7 +182,7 @@ function upcomingCartridgeData(kind: PillState['kind'], typeKey: string | undefi
 }
 
 /** Build the cartridgeId `${kind}-${dayIndex}-${typeKey}` scheme. */
-function cartridgeIdFor(kind: PillState['kind'], dayIndex: number, typeKey: string | undefined): string {
+function cartridgeIdFor(kind: CartridgeKind, dayIndex: number, typeKey: string | undefined): string {
   return `${kind}-${dayIndex}-${typeKey || 'UNKNOWN'}`;
 }
 
@@ -83,6 +208,9 @@ export function usePillStates(): PillState[] {
   const manifest = useGameStore(s => s.manifest);
   const dayIndex = useGameStore(s => s.dayIndex);
   const playerId = useGameStore(s => s.playerId);
+  // Tick once per second so countdown meta strings update without store
+  // mutations driving the re-render.
+  const tickNow = useNowTick(1000);
 
   return useMemo(() => {
     const pills: PillState[] = [];
@@ -275,6 +403,7 @@ export function usePillStates(): PillState[] {
             lifecycle: 'upcoming',
             timeRemaining: Math.floor((eventTime - now) / 1000),
             cartridgeData,
+            startTime: eventTime,
           });
         } else {
           pills.push({
@@ -283,11 +412,315 @@ export function usePillStates(): PillState[] {
             label,
             lifecycle: 'starting',
             cartridgeData,
+            startTime: eventTime,
           });
         }
       }
     }
 
+    // ── Social-window pills (DMs / group chat) ──────────────────────────────
+    // Pair OPEN_* and CLOSE_* timeline events into single window pills with
+    // start + end times. Skip the urgent / acted / unread treatments (per
+    // mockup): social windows are not cartridges and have no "result".
+    if (day?.timeline && manifest?.scheduling === 'PRE_SCHEDULED') {
+      const now = Date.now();
+      const tl = day.timeline as any[];
+      // Collect already-paired open events keyed by (action, time) so duplicates
+      // (rare, but possible if a manifest is regenerated) don't double-emit.
+      for (let i = 0; i < tl.length; i++) {
+        const ev = tl[i];
+        const meta = SOCIAL_OPEN_ACTIONS[ev.action];
+        if (!meta) continue;
+        const openTime = ev.time?.includes('T') ? new Date(ev.time).getTime() : null;
+        if (openTime === null) continue;
+
+        // Find the next CLOSE_* of the same kind after this open. The playtest
+        // preset interleaves multiple open/close pairs — pair to the nearest
+        // future close.
+        let closeTime: number | null = null;
+        for (let j = i + 1; j < tl.length; j++) {
+          if (tl[j].action === meta.closeAction && tl[j].time?.includes('T')) {
+            const t = new Date(tl[j].time).getTime();
+            if (t >= openTime) { closeTime = t; break; }
+          }
+        }
+        // Lifecycle: upcoming → needs-action (during window) → completed.
+        // Reuse needs-action visually because the design "active treatment"
+        // applies; ACT_VERB / urgent / dot are gated on isSocialWindow in
+        // Pill.tsx so the social pill stays calm-active without action verbs.
+        const lifecycle: PillLifecycle =
+          now < openTime ? 'upcoming'
+          : (closeTime !== null && now >= closeTime) ? 'completed'
+          : 'needs-action';
+
+        pills.push({
+          id: `${meta.kind}-${dayIndex}-${ev.time}`,
+          kind: meta.kind,
+          label: meta.label,
+          lifecycle,
+          isSocialWindow: true,
+          startTime: openTime,
+          endTime: closeTime ?? undefined,
+        });
+      }
+    }
+
+    // ── Cartridge close-time stamping + urgent upgrade ──────────────────────
+    // PRE_SCHEDULED only. Walks CLOSE_VOTING / END_GAME / END_ACTIVITY /
+    // END_DILEMMA timeline entries. For every matching active pill, stamp
+    // endTime so countdowns can be formatted. Additionally upgrade
+    // needs-action → urgent when the player hasn't acted and close is within
+    // URGENT_THRESHOLD_MS.
+    if (day?.timeline && manifest?.scheduling === 'PRE_SCHEDULED') {
+      const now = tickNow;
+      for (const ev of day.timeline as any[]) {
+        if (!ev.time?.includes('T')) continue;
+        const closeTime = new Date(ev.time).getTime();
+        for (const k of Object.keys(CLOSE_ACTION_FOR_CARTRIDGE) as CartridgeKind[]) {
+          if (CLOSE_ACTION_FOR_CARTRIDGE[k] !== ev.action) continue;
+          // Stamp endTime on every active-or-acted pill of this kind.
+          const live = pills.find(
+            p => p.kind === k && (p.lifecycle === 'needs-action' || p.lifecycle === 'in-progress'),
+          );
+          if (live && live.endTime === undefined) live.endTime = closeTime;
+          // Urgent upgrade
+          if (closeTime > now && closeTime - now <= URGENT_THRESHOLD_MS) {
+            const pill = pills.find(p => p.kind === k && p.lifecycle === 'needs-action');
+            if (pill && !pill.playerActed) {
+              pill.lifecycle = 'urgent';
+              pill.endTime = closeTime;
+            }
+          }
+        }
+      }
+    }
+
+    // ── Phase detection ────────────────────────────────────────────────────
+    // pregame: before the day's first timeline event
+    // night:   after END_DAY (or last timeline event)
+    // day:     between
+    let phase: 'pregame' | 'day' | 'night' = 'day';
+    let dayStartMs: number | null = null;
+    let dayEndMs: number | null = null;
+    if (day?.timeline && manifest?.scheduling === 'PRE_SCHEDULED') {
+      const tl = (day.timeline as any[]).filter(e => e.time?.includes('T'));
+      if (tl.length > 0) {
+        const times = tl.map(e => new Date(e.time).getTime());
+        dayStartMs = Math.min(...times);
+        const endDay = tl.find(e => e.action === 'END_DAY');
+        dayEndMs = endDay ? new Date(endDay.time).getTime() : Math.max(...times);
+        const now = Date.now();
+        if (now < dayStartMs) phase = 'pregame';
+        else if (dayEndMs !== null && now >= dayEndMs) phase = 'night';
+        else phase = 'day';
+      }
+    }
+
+    // ── Debug: ?force-urgent=voting|game|prompt|dilemma ────────────────────
+    // Visual-test path for the urgent visual when timing/manifest doesn't
+    // naturally produce one. App.tsx stashes the param into sessionStorage
+    // before stripping the URL on game-route entry; readForceUrgent() pulls
+    // from there.
+    const forced = readForceUrgent();
+    if (forced) {
+      let target = pills.find(p => p.kind === forced);
+      if (!target) {
+        target = {
+          id: `forced-${forced}`,
+          kind: forced,
+          label: forced === 'voting' ? 'Vote' : forced === 'game' ? 'Wager' : forced === 'prompt' ? 'Prompt' : 'Dilemma',
+          lifecycle: 'urgent',
+          startTime: tickNow - 60_000,
+        };
+        pills.push(target);
+      }
+      target.lifecycle = 'urgent';
+      target.endTime = tickNow + 4 * 60 * 1000;
+      target.playerActed = false;
+    }
+
+    // ── Format meta strings ────────────────────────────────────────────────
+    // Per-state copy that ticks with `tickNow`. Pill.tsx is a dumb renderer
+    // for these strings.
+    for (const p of pills) {
+      p.meta = formatPillMeta(p, tickNow);
+    }
+
+    // ── Chronological sort (active/upcoming pills) ─────────────────────────
+    // Sort by startTime ascending. Active pills without startTime go first
+    // (they're already running). Completed pills go after upcoming so the
+    // row reads chronologically left-to-right within a day.
+    pills.sort((a, b) => {
+      const sa = a.startTime ?? 0;
+      const sb = b.startTime ?? 0;
+      return sa - sb;
+    });
+
+    // ── Boundary pill ──────────────────────────────────────────────────────
+    // Always present, anchors the day's right edge (mini variant during day)
+    // or stands alone as a hero anchor (pregame / night).
+    //
+    // The pregame-only-shows-boundary rule lives at the render layer
+    // (PulseBar) so CartridgeOverlay's pill-by-id lookup still works during
+    // pregame for programmatically-focused cartridges (e.g., deep links).
+    const boundary = buildBoundaryPill({ phase, dayStartMs, dayEndMs, now: tickNow, dayIndex });
+    if (boundary) {
+      boundary.meta = formatPillMeta(boundary, tickNow);
+      pills.push(boundary);
+    }
+
     return pills;
-  }, [voting, game, prompt, dilemma, completed, manifest, dayIndex, playerId]);
+  }, [voting, game, prompt, dilemma, completed, manifest, dayIndex, playerId, tickNow]);
+}
+
+/**
+ * Per-state meta copy. Returns the right-of-label microcopy that pairs with
+ * the pill's lifecycle. Recomputes on every tick so countdowns are live.
+ */
+function formatPillMeta(p: PillState, now: number): string | undefined {
+  // Boundary mini variant: "17:00 · in 12m" (the hero variant uses pill.hero
+  // and ignores meta).
+  if (p.kind === 'boundary') {
+    if (p.hero) return undefined;
+    if (p.endTime === undefined) return undefined;
+    return `${formatClock(p.endTime)} · in ${formatRelative(p.endTime - now)}`;
+  }
+
+  // Social windows
+  if (p.isSocialWindow) {
+    if (p.lifecycle === 'upcoming' && p.startTime !== undefined) return formatClock(p.startTime);
+    if (p.lifecycle === 'needs-action') {
+      if (p.endTime !== undefined) {
+        const remaining = p.endTime - now;
+        return remaining < 60 * 60 * 1000
+          ? `open · ${formatCountdown(remaining)}`
+          : `open · ends ${formatClock(p.endTime)}`;
+      }
+      return 'open';
+    }
+    if (p.lifecycle === 'completed') return 'closed';
+    return undefined;
+  }
+
+  // Cartridges
+  switch (p.lifecycle) {
+    case 'upcoming':
+      return p.startTime !== undefined ? formatClock(p.startTime) : undefined;
+    case 'starting':
+      return 'starting…';
+    case 'just-started':
+    case 'needs-action':
+    case 'urgent':
+      return p.endTime !== undefined ? formatCountdown(p.endTime - now) : undefined;
+    case 'in-progress':
+      // Acted: verb microcopy is rendered separately by Pill.tsx (italic
+      // kind-color span), then the countdown follows.
+      return p.endTime !== undefined ? formatCountdown(p.endTime - now) : undefined;
+    case 'completed':
+      return 'result';
+  }
+  return undefined;
+}
+
+/** "5m 30s left" / "1h 12m left" — standalone meta. */
+function formatCountdown(ms: number): string {
+  const m = Math.max(0, ms / 60_000);
+  const mInt = Math.floor(m);
+  const sInt = Math.max(0, Math.floor((m - mInt) * 60));
+  if (m < 60) return `${mInt}m ${String(sInt).padStart(2, '0')}s left`;
+  const hh = Math.floor(mInt / 60);
+  const mm = mInt % 60;
+  return `${hh}h ${String(mm).padStart(2, '0')}m left`;
+}
+
+/**
+ * Build the boundary pill ("Day starts" / "Day ends" / "Night") based on
+ * phase. Hero variant in pregame & night carries an eyebrow + body + rel
+ * countdown. Mini variant during day shows label + meta with end-time.
+ */
+function buildBoundaryPill(opts: {
+  phase: 'pregame' | 'day' | 'night';
+  dayStartMs: number | null;
+  dayEndMs: number | null;
+  now: number;
+  dayIndex: number;
+}): PillState | null {
+  const { phase, dayStartMs, dayEndMs, now, dayIndex } = opts;
+
+  if (phase === 'pregame' && dayStartMs !== null) {
+    return {
+      id: 'boundary-pregame',
+      kind: 'boundary',
+      label: `Day ${dayIndex} starts`,
+      lifecycle: 'upcoming',
+      startTime: dayStartMs,
+      endTime: dayStartMs,
+      hero: {
+        eyebrow: `Day ${dayIndex} starts`,
+        body: formatClock(dayStartMs),
+        rel: formatRelative(dayStartMs - now),
+      },
+    };
+  }
+
+  if (phase === 'night' && dayEndMs !== null) {
+    // Next-day open is a guess (24h after this morning's open) — refined when
+    // tomorrow's manifest day lands. Hero copy reads symmetrically with the
+    // pregame anchor: eyebrow names the next day, body is the clock time,
+    // rel is the bare relative — BoundaryHeroPill adds the "in" prefix.
+    const nextOpen = (dayStartMs ?? dayEndMs) + 24 * 60 * 60 * 1000;
+    return {
+      id: 'boundary-night',
+      kind: 'boundary',
+      label: `Day ${dayIndex + 1} starts`,
+      lifecycle: 'upcoming',
+      startTime: Number.MAX_SAFE_INTEGER, // boundary always last
+      endTime: nextOpen,
+      hero: {
+        eyebrow: `Day ${dayIndex + 1} starts`,
+        body: formatClock(nextOpen),
+        rel: formatRelative(nextOpen - now),
+      },
+    };
+  }
+
+  if (phase === 'day' && dayEndMs !== null) {
+    // Escalate the lifecycle when day-end is imminent. The mini boundary
+    // pill is calm by default; flipping to 'urgent' inside Pill.tsx triggers
+    // the bolder "phase ending soon" treatment (accent ring + faster pulse)
+    // so a row reading "Day ends · in 3m" feels appropriately loud without
+    // taking over the screen.
+    const remainingMs = dayEndMs - now;
+    const lifecycle: PillLifecycle =
+      remainingMs > 0 && remainingMs <= 5 * 60 * 1000 ? 'urgent' : 'upcoming';
+    return {
+      id: 'boundary-day',
+      kind: 'boundary',
+      label: 'Day ends',
+      lifecycle,
+      startTime: Number.MAX_SAFE_INTEGER, // anchors right edge
+      endTime: dayEndMs,
+    };
+  }
+
+  return null;
+}
+
+/** "10:00" / "16:00" — 24h clock for hero body. */
+function formatClock(ms: number): string {
+  const d = new Date(ms);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+/** Used after "in" prefix; no trailing "left". "5m" / "1h 30m" / "12s". */
+function formatRelative(ms: number): string {
+  const m = Math.max(0, Math.floor(ms / 60_000));
+  if (m < 1) {
+    const s = Math.max(0, Math.floor(ms / 1000));
+    return `${s}s`;
+  }
+  if (m < 60) return `${m}m`;
+  const hh = Math.floor(m / 60);
+  const mm = m % 60;
+  return mm === 0 ? `${hh}h` : `${hh}h ${String(mm).padStart(2, '0')}m`;
 }

--- a/apps/client/src/shells/pulse/icons.ts
+++ b/apps/client/src/shells/pulse/icons.ts
@@ -66,6 +66,7 @@ export {
   Trophy,
   Users,
   UsersThree,
+  Clock,
 
   // Reveal (per-mechanism elimination icons)
   HeartBreak,

--- a/apps/client/src/shells/pulse/pulse-theme.css
+++ b/apps/client/src/shells/pulse/pulse-theme.css
@@ -24,6 +24,10 @@
   --pulse-game: oklch(0.837 0.164 84);
   --pulse-prompt: oklch(0.714 0.143 255);
   --pulse-dilemma: oklch(0.722 0.177 306);
+  /* Social-window family — DMs + group chat share one cream hue. Distinct
+     from saturated cartridge palette; differentiated by icon, not color. */
+  --pulse-social: oklch(0.890 0.060 80);
+  --pulse-gold-soft: color-mix(in oklch, var(--pulse-gold) 28%, transparent);
   --pulse-online: oklch(0.746 0.181 152);
   --pulse-pending: oklch(0.754 0.164 50);
   --pulse-on-accent: #fff;
@@ -100,10 +104,63 @@
   50% { opacity: 1; }
 }
 
-/* Pill urgency pulse */
+/* Pill urgency pulse — accent-pink shadow swing. The kind-glow is dropped on
+   urgent (vs. needs-action / active) so the alarm reads as categorically
+   different, not "louder version of active". 700ms outpaces the active
+   heartbeat (2.4s) so it visibly demands attention. */
 @keyframes pulse-pill-urgent {
+  0%, 100% {
+    box-shadow:
+      0 0 28px color-mix(in oklch, var(--pulse-accent) 55%, transparent),
+      inset 0 0 0 1px color-mix(in oklch, var(--pulse-text-1) 6%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 36px color-mix(in oklch, var(--pulse-accent) 85%, transparent),
+      inset 0 0 0 1px color-mix(in oklch, var(--pulse-text-1) 6%, transparent);
+  }
+}
+.pulse-pill-urgent {
+  animation: pulse-pill-urgent 700ms ease-in-out infinite;
+}
+
+/* Boundary imminence — gold base + accent overlay swing. Gold stays
+   load-bearing; the accent layer is the "the day's ending" overlay. Faster
+   than calm, slower than cartridge-urgent so it doesn't read as identical. */
+@keyframes pulse-pill-boundary-imminent {
+  0%, 100% {
+    box-shadow:
+      0 0 22px color-mix(in oklch, var(--pulse-gold) 60%, transparent),
+      0 0 14px color-mix(in oklch, var(--pulse-accent) 40%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 32px color-mix(in oklch, var(--pulse-gold) 90%, transparent),
+      0 0 22px color-mix(in oklch, var(--pulse-accent) 70%, transparent);
+  }
+}
+.pulse-pill-boundary-imminent {
+  animation: pulse-pill-boundary-imminent 1.1s ease-in-out infinite;
+}
+
+/* Active pill heartbeat — applied to a child wrapper inside the pill button,
+   not the button itself, so framer-motion's hover/tap transforms (translateY,
+   scale) don't conflict with this keyframe's transform. CSS keyframes and
+   inline transform on the same element overwrite each other; nesting keeps
+   them on separate transform stacks.
+   Duration tuned softer (3s) than initial 2.4s after multi-active feedback
+   read as strobing. Pill.tsx applies a deterministic per-pill animation-delay
+   so two simultaneously-active pills don't pulse in lockstep. */
+@keyframes pulse-pill-active-heartbeat {
   0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.02); }
+  50%      { transform: scale(1.025); }
+}
+.pulse-pill-active-heartbeat {
+  animation: pulse-pill-active-heartbeat 3s ease-in-out infinite;
+  transform-origin: center;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pulse-pill-active-heartbeat { animation: none; }
 }
 
 /* Upcoming pill breathing — reads as "coming, don't forget me" instead of

--- a/apps/game-server/src/__tests__/push-intent-phase.test.ts
+++ b/apps/game-server/src/__tests__/push-intent-phase.test.ts
@@ -23,10 +23,10 @@ describe('phasePushPayload — intents', () => {
   });
 
   it('ACTIVITY returns cartridge_active with prompt kind', () => {
-    const result = phasePushPayload('ACTIVITY', 3, { ...dayManifest, promptType: 'POLL' } as any);
+    const result = phasePushPayload('ACTIVITY', 3, { ...dayManifest, activityType: 'HOT_TAKE' } as any);
     expect(result?.intent).toEqual({
       kind: 'cartridge_active',
-      cartridgeId: 'prompt-3-POLL',
+      cartridgeId: 'prompt-3-HOT_TAKE',
       cartridgeKind: 'prompt',
     });
   });
@@ -37,8 +37,8 @@ describe('phasePushPayload — intents', () => {
   });
 
   it('END_ACTIVITY returns cartridge_result with prompt kind', () => {
-    const result = phasePushPayload('END_ACTIVITY', 3, { promptType: 'POLL' } as any);
-    expect(result?.intent).toEqual({ kind: 'cartridge_result', cartridgeId: 'prompt-3-POLL' });
+    const result = phasePushPayload('END_ACTIVITY', 3, { activityType: 'HOT_TAKE' } as any);
+    expect(result?.intent).toEqual({ kind: 'cartridge_result', cartridgeId: 'prompt-3-HOT_TAKE' });
   });
 
   it('DAY_START, NIGHT_SUMMARY, OPEN/CLOSE gates return main intent', () => {

--- a/apps/game-server/src/__tests__/push-triggers-confessions.test.ts
+++ b/apps/game-server/src/__tests__/push-triggers-confessions.test.ts
@@ -13,10 +13,11 @@ describe('PushTriggerSchema — CONFESSION_OPEN', () => {
 });
 
 describe('phasePushPayload — CONFESSION_OPEN', () => {
-  it('returns "A confession phase has opened." with main intent', () => {
+  it('returns confession booth copy with main intent', () => {
     const result = phasePushPayload('CONFESSION_OPEN', 2);
     expect(result).not.toBeNull();
-    expect(result!.payload.body).toBe('A confession phase has opened.');
+    expect(result!.payload.title).toBe('Confession booth · Open');
+    expect(result!.payload.body).toBe('Spill in private. Just for you.');
     expect(result!.intent).toEqual({ kind: 'main' });
   });
 });

--- a/apps/game-server/src/http-handlers.ts
+++ b/apps/game-server/src/http-handlers.ts
@@ -257,8 +257,8 @@ async function handlePushGameEntry(ctx: HandlerContext, req: Request): Promise<R
 
     const url = `${ctx.env.GAME_CLIENT_HOST}/game/${inviteCode}`;
     const result = await sendPushNotification(sub, {
-      title: 'Pecking Order',
-      body: 'Your game is ready! Tap to play.',
+      title: 'Your game starts now',
+      body: 'Day 1. Your cast is waiting.',
       url,
       token,
     }, ctx.env.VAPID_PRIVATE_JWK);

--- a/apps/game-server/src/push-triggers.ts
+++ b/apps/game-server/src/push-triggers.ts
@@ -9,7 +9,7 @@
  * so each push fires exactly once. No client-side tag dedup needed.
  */
 import type { PushTrigger, GameManifest, DailyManifest, DeepLinkIntent } from "@pecking-order/shared-types";
-import { DEFAULT_PUSH_CONFIG, FactTypes } from "@pecking-order/shared-types";
+import { DEFAULT_PUSH_CONFIG, FactTypes, CARTRIDGE_INFO } from "@pecking-order/shared-types";
 import { getPushSubscriptionD1, deletePushSubscriptionD1 } from "./d1-persistence";
 import { sendPushNotification } from "./push-send";
 
@@ -20,38 +20,24 @@ const DM_TTL = 3600;          // 1 hour — direct messages
 const ELIMINATION_TTL = 3600; // 1 hour
 const WINNER_TTL = 86400;     // 24 hours — game conclusion
 
-// --- Human-friendly mechanic labels for push notifications ---
+// Display name + tagline for a cartridge type. Falls back gracefully if the
+// type is missing from CARTRIDGE_INFO (e.g. mid-rollout enum additions). We
+// read from CARTRIDGE_INFO (the canonical registry) instead of a local map so
+// that new games/votes/activities surface in pushes without a parallel update
+// here — see `reference_cartridge_info.md`.
+function displayOf(type: string, fallback: string): string {
+  return CARTRIDGE_INFO[type]?.displayName ?? fallback;
+}
+function taglineOf(type: string): string | null {
+  return CARTRIDGE_INFO[type]?.tagline ?? null;
+}
 
-const GAME_LABELS: Record<string, string> = {
-  TRIVIA: 'Trivia',
-  REALTIME_TRIVIA: 'Live Trivia',
-  GAP_RUN: 'Gap Run',
-  GRID_PUSH: 'Grid Push',
-  SEQUENCE: 'Sequence',
-  REACTION_TIME: 'Reaction Time',
-  COLOR_MATCH: 'Color Match',
-  STACKER: 'Stacker',
-  QUICK_MATH: 'Quick Math',
-  SIMON_SAYS: 'Simon Says',
-  AIM_TRAINER: 'Aim Trainer',
-  BET_BET_BET: 'Bet Bet Bet',
-  BLIND_AUCTION: 'Blind Auction',
-  KINGS_RANSOM: "King's Ransom",
-  THE_SPLIT: 'The Split',
-  TOUCH_SCREEN: 'Touch Screen',
-};
-
-const VOTE_LABELS: Record<string, string> = {
-  MAJORITY: 'Majority Vote',
-  EXECUTIONER: 'The Executioner',
-  BUBBLE: 'The Bubble',
-  SECOND_TO_LAST: 'Second to Last',
-  PODIUM_SACRIFICE: 'Podium Sacrifice',
-  SHIELD: 'The Shield',
-  TRUST_PAIRS: 'Trust Pairs',
-  FINALS: 'The Finals',
-  DUELS: 'Duels',
-};
+// Pick a random entry from a non-empty list. Used for body-copy pools where
+// variation across repeated firings keeps the notification feeling alive
+// instead of templated.
+function pick<T>(items: readonly T[]): T {
+  return items[Math.floor(Math.random() * items.length)] as T;
+}
 
 export interface PushContext {
   roster: Record<string, any>;
@@ -127,42 +113,68 @@ export function phasePushPayload(
 ): { payload: Record<string, string>; ttl: number; intent: DeepLinkIntent } | null {
   const gameType = dayManifest?.gameType || 'UNKNOWN';
   const voteType = dayManifest?.voteType || 'UNKNOWN';
-  const promptType = (dayManifest as any)?.promptType || 'UNKNOWN';
-  const gameLabel = GAME_LABELS[gameType] || 'Game';
-  const voteLabel = VOTE_LABELS[voteType] || 'Voting';
+  // Manifest field is `activityType` (PromptType), NOT `promptType` — earlier
+  // versions of this file read the wrong key and silently degraded to 'UNKNOWN',
+  // which is why ACTIVITY/END_ACTIVITY pushes never named the prompt.
+  const activityType = dayManifest?.activityType || 'UNKNOWN';
+  const dilemmaType = dayManifest?.dilemmaType || 'UNKNOWN';
+  const gameDisplay = displayOf(gameType, 'Game');
+  const voteDisplay = displayOf(voteType, 'Vote');
+  const activityDisplay = displayOf(activityType, 'Today\'s prompt');
+  const dilemmaDisplay = displayOf(dilemmaType, 'Dilemma');
+  const voteTagline = taglineOf(voteType) ?? 'Sundown decides.';
+  const gameTagline = taglineOf(gameType) ?? 'Show off, or get shown up.';
+  const activityTagline = taglineOf(activityType) ?? 'Drop your answer for silver.';
+  const dilemmaTagline = taglineOf(dilemmaType) ?? 'Choose carefully.';
 
   switch (trigger) {
     case 'DAY_START':
-      return { payload: { title: `Day ${dayIndex}`, body: `A new day dawns at Pecking Order. Today's vote: ${voteLabel}` }, ttl: EVENT_TTL, intent: { kind: 'main' } };
+      return { payload: { title: `Day ${dayIndex} · ${voteDisplay}`, body: voteTagline }, ttl: EVENT_TTL, intent: { kind: 'main' } };
     case 'VOTING':
-      return { payload: { title: voteLabel, body: `Day ${dayIndex} voting is open — cast your vote now` }, ttl: EVENT_TTL,
+      return { payload: { title: `Vote · ${voteDisplay}`, body: `${voteTagline} Cast yours.` }, ttl: EVENT_TTL,
                intent: { kind: 'cartridge_active', cartridgeId: `voting-${dayIndex}-${voteType}`, cartridgeKind: 'voting' } };
-    case 'NIGHT_SUMMARY':
-      return { payload: { title: "Night has fallen", body: `Day ${dayIndex} results are in...` }, ttl: EVENT_TTL, intent: { kind: 'main' } };
+    case 'NIGHT_SUMMARY': {
+      // Name what actually happened today (game + vote) when we can; fall back
+      // to a generic recap line if the manifest doesn't carry both.
+      const hasGame = gameType !== 'UNKNOWN' && gameType !== 'NONE';
+      const hasVote = voteType !== 'UNKNOWN';
+      const body = hasGame && hasVote
+        ? `${gameDisplay} · ${voteDisplay}. Recap inside.`
+        : hasVote
+          ? `${voteDisplay}. Recap inside.`
+          : 'Recap is in. Spoilers inside.';
+      return { payload: { title: `Day ${dayIndex} wrap`, body }, ttl: EVENT_TTL, intent: { kind: 'main' } };
+    }
     case 'DAILY_GAME':
-      return { payload: { title: `${gameLabel} Time`, body: `Today's game is ${gameLabel} — jump in and play` }, ttl: EVENT_TTL,
+      return { payload: { title: `${gameDisplay} is live`, body: gameTagline }, ttl: EVENT_TTL,
                intent: { kind: 'cartridge_active', cartridgeId: `game-${dayIndex}-${gameType}`, cartridgeKind: 'game' } };
     case 'ACTIVITY':
-      return { payload: { title: "Activity Time", body: `A new activity is live — earn some silver` }, ttl: EVENT_TTL,
-               intent: { kind: 'cartridge_active', cartridgeId: `prompt-${dayIndex}-${promptType}`, cartridgeKind: 'prompt' } };
+      return { payload: { title: `${activityDisplay} is live`, body: activityTagline }, ttl: EVENT_TTL,
+               intent: { kind: 'cartridge_active', cartridgeId: `prompt-${dayIndex}-${activityType}`, cartridgeKind: 'prompt' } };
     case 'OPEN_DMS':
-      return { payload: { title: "DMs Open", body: "Send private messages, form alliances, make deals" }, ttl: EVENT_TTL, intent: { kind: 'main' } };
+      return { payload: { title: 'DMs are open', body: 'Plot in private. Strike a deal. Or break one.' }, ttl: EVENT_TTL, intent: { kind: 'main' } };
     case 'CLOSE_DMS':
-      return { payload: { title: "DMs Closed", body: "Private messages are closed for the day" }, ttl: EVENT_TTL, intent: { kind: 'main' } };
+      return { payload: { title: 'DMs are locked', body: 'Whatever you said, you said. Until tomorrow.' }, ttl: EVENT_TTL, intent: { kind: 'main' } };
     case 'OPEN_GROUP_CHAT':
-      return { payload: { title: "Group Chat Open", body: "The floor is open — make your case" }, ttl: EVENT_TTL, intent: { kind: 'main' } };
+      return { payload: { title: 'The floor is open', body: 'Make your case. Plot moves. Bluff hard.' }, ttl: EVENT_TTL, intent: { kind: 'main' } };
     case 'CLOSE_GROUP_CHAT':
-      return { payload: { title: "Group Chat Closed", body: "The group chat has closed for the day" }, ttl: EVENT_TTL, intent: { kind: 'main' } };
+      return { payload: { title: 'Main chat is closed', body: 'Plays are in. Sundown comes for someone.' }, ttl: EVENT_TTL, intent: { kind: 'main' } };
     case 'END_GAME':
-      return { payload: { title: `${gameLabel} Complete`, body: "Results are in — check how you did" }, ttl: EVENT_TTL,
+      return { payload: { title: `${gameDisplay} · Recap`, body: 'See who flexed, see who flopped.' }, ttl: EVENT_TTL,
                intent: { kind: 'cartridge_result', cartridgeId: `game-${dayIndex}-${gameType}` } };
     case 'END_ACTIVITY':
-      return { payload: { title: "Activity Complete", body: "Results are in — see who earned silver" }, ttl: EVENT_TTL,
-               intent: { kind: 'cartridge_result', cartridgeId: `prompt-${dayIndex}-${promptType}` } };
+      return { payload: { title: `${activityDisplay} · Recap`, body: 'Silver hit. See who got paid.' }, ttl: EVENT_TTL,
+               intent: { kind: 'cartridge_result', cartridgeId: `prompt-${dayIndex}-${activityType}` } };
+    case 'DILEMMA':
+      return { payload: { title: `${dilemmaDisplay} is live`, body: dilemmaTagline }, ttl: EVENT_TTL,
+               intent: { kind: 'cartridge_active', cartridgeId: `dilemma-${dayIndex}-${dilemmaType}`, cartridgeKind: 'dilemma' } };
+    case 'END_DILEMMA':
+      return { payload: { title: `${dilemmaDisplay} · Recap`, body: 'Choices made. See the fallout.' }, ttl: EVENT_TTL,
+               intent: { kind: 'cartridge_result', cartridgeId: `dilemma-${dayIndex}-${dilemmaType}` } };
     case 'CONFESSION_OPEN':
       // Plan 1 routes to chat-root (no deep-link intent into a cartridge yet — Plan 2's match
       // cartridge gets its own START_ACTIVITY push when it spawns later).
-      return { payload: { title: 'Confession', body: 'A confession phase has opened.' }, ttl: EVENT_TTL, intent: { kind: 'main' } };
+      return { payload: { title: 'Confession booth · Open', body: 'Spill in private. Just for you.' }, ttl: EVENT_TTL, intent: { kind: 'main' } };
     default:
       return null;
   }
@@ -180,35 +192,36 @@ export function handleFactPush(
   if (fact.type === FactTypes.CHAT_MSG && fact.payload?.channelId === 'MAIN') {
     // Priority: REPLY > MENTION > GROUP_CHAT_MSG. Each recipient gets at
     // most one push per message; more-specific triggers suppress the generic
-    // group-chat broadcast for that player.
-    const title = name(fact.actorId);
+    // group-chat broadcast for that player. Mentions and replies get a
+    // distinguishing title so they stand out from group-chat noise.
+    const senderName = name(fact.actorId);
     const body = (fact.payload?.content || '').slice(0, 100);
-    const payload = { title, body };
     const replyToAuthorId: string | undefined = fact.payload?.replyToAuthorId;
     const mentionedIds: string[] = Array.isArray(fact.payload?.mentionedIds) ? fact.payload.mentionedIds : [];
     const exclude = new Set<string>([fact.actorId]);
 
     const promises: Promise<void>[] = [];
     if (replyToAuthorId && replyToAuthorId !== fact.actorId && isPushEnabled(manifest, 'REPLY')) {
-      promises.push(pushToPlayer(ctx, replyToAuthorId, payload, EVENT_TTL, { kind: 'main' }));
+      promises.push(pushToPlayer(ctx, replyToAuthorId, { title: `${senderName} replied to you`, body }, EVENT_TTL, { kind: 'main' }));
       exclude.add(replyToAuthorId);
     }
     if (isPushEnabled(manifest, 'MENTION')) {
       for (const mid of mentionedIds) {
         if (exclude.has(mid)) continue;
-        promises.push(pushToPlayer(ctx, mid, payload, EVENT_TTL, { kind: 'main' }));
+        promises.push(pushToPlayer(ctx, mid, { title: `${senderName} mentioned you`, body }, EVENT_TTL, { kind: 'main' }));
         exclude.add(mid);
       }
     }
     if (isPushEnabled(manifest, 'GROUP_CHAT_MSG')) {
-      promises.push(pushBroadcast(ctx, payload, EVENT_TTL, Array.from(exclude), { kind: 'main' }));
+      promises.push(pushBroadcast(ctx, { title: senderName, body }, EVENT_TTL, Array.from(exclude), { kind: 'main' }));
     }
     if (promises.length === 0) return;
     return Promise.allSettled(promises).then(() => {}).catch(err => console.error('[L1] [Push] Error:', err));
   } else if (fact.type === FactTypes.DM_SENT) {
     if (!isPushEnabled(manifest, 'DM_SENT')) return;
+    const senderName = name(fact.actorId);
     const snippet = (fact.payload?.content || '').slice(0, 100);
-    const payload = { title: name(fact.actorId), body: snippet || 'Sent you a message' };
+    const payload = { title: senderName, body: snippet || `${senderName} DM'd you` };
     const channelId = fact.payload?.channelId as string | undefined;
     const intent: DeepLinkIntent | undefined = channelId ? { kind: 'dm', channelId } : undefined;
 
@@ -231,47 +244,59 @@ export function handleFactPush(
     const intent: DeepLinkIntent | undefined = dayIndex !== undefined
       ? { kind: 'elimination_reveal', dayIndex }
       : undefined;
+    const targetName = name(fact.targetId || fact.actorId);
+    const dayLabel = typeof dayIndex === 'number' ? `Day ${dayIndex}` : 'Today';
     return pushBroadcast(ctx, {
-      title: 'Pecking Order',
-      body: `${name(fact.targetId || fact.actorId)} has been eliminated!`,
+      title: `${targetName} is OUT`,
+      body: pick([
+        `${dayLabel} is brutal. Tap in.`,
+        `It's bad. Tap to watch.`,
+        `The replay's wild. Catch up.`,
+      ]),
     }, ELIMINATION_TTL, undefined, intent).catch(err => console.error('[L1] [Push] Error:', err));
   } else if (fact.type === FactTypes.WINNER_DECLARED) {
     if (!isPushEnabled(manifest, 'WINNER_DECLARED')) return;
+    const winnerName = name(fact.targetId || fact.actorId);
     return pushBroadcast(ctx, {
-      title: 'Pecking Order',
-      body: `${name(fact.targetId || fact.actorId)} wins!`,
+      title: `${winnerName} is CROWNED`,
+      body: '7 days. One winner. Tap to watch.',
     }, WINNER_TTL, undefined, { kind: 'winner_reveal' }).catch(err => console.error('[L1] [Push] Error:', err));
   } else if (fact.type === FactTypes.DM_INVITE_SENT && fact.payload?.memberIds) {
     if (!isPushEnabled(manifest, 'DM_SENT')) return;  // reuse DM_SENT toggle
     const memberIds = fact.payload.memberIds as string[];
+    const inviterName = name(fact.actorId);
     const intent: DeepLinkIntent = { kind: 'dm_invite', senderId: fact.actorId };
     return Promise.all(
       memberIds.map((memberId: string) =>
         pushToPlayer(ctx, memberId, {
-          title: name(fact.actorId),
-          body: `${name(fact.actorId)} invited you to chat`,
+          title: `${inviterName} opened a DM with you`,
+          body: 'Tap to accept.',
         }, DM_TTL, intent)
       )
     ).then(() => {}).catch(err => console.error('[L1] [Push] Error:', err));
   } else if (fact.type === FactTypes.NUDGE && fact.targetId) {
     if (!isPushEnabled(manifest, 'NUDGE')) return;
     return pushToPlayer(ctx, fact.targetId, {
-      title: name(fact.actorId),
-      body: `${name(fact.actorId)} nudged you`,
+      title: `${name(fact.actorId)} nudged you`,
+      body: pick(['Hey. Look up.', "Don't ghost.", 'Eyes on you.']),
     }, EVENT_TTL, { kind: 'main' }).catch(err => console.error('[L1] [Push] Error:', err));
   } else if (fact.type === FactTypes.WHISPER && fact.targetId) {
     if (!isPushEnabled(manifest, 'WHISPER')) return;
     const text = (fact.payload?.text || '').slice(0, 100);
     return pushToPlayer(ctx, fact.targetId, {
       title: `${name(fact.actorId)} whispered`,
-      body: text || 'Whispered to you',
+      body: text || 'Tap to read.',
     }, EVENT_TTL, { kind: 'main' }).catch(err => console.error('[L1] [Push] Error:', err));
   } else if (fact.type === FactTypes.SILVER_TRANSFER && fact.targetId) {
     if (!isPushEnabled(manifest, 'SILVER_RECEIVED')) return;
     const amount = fact.payload?.amount ?? 0;
     return pushToPlayer(ctx, fact.targetId, {
-      title: name(fact.actorId),
-      body: `${name(fact.actorId)} sent you ${amount} silver`,
+      title: `${name(fact.actorId)} sent ${amount} silver`,
+      body: pick([
+        'Tap. They probably want something.',
+        'Bribe? Gift? Tap to see.',
+        'Suspicious. Tap in.',
+      ]),
     }, EVENT_TTL, { kind: 'main' }).catch(err => console.error('[L1] [Push] Error:', err));
   }
 }

--- a/apps/lobby/.impeccable.md
+++ b/apps/lobby/.impeccable.md
@@ -1,0 +1,114 @@
+# Pecking Order — Lobby
+
+This is the design context for the **Lobby** (Next.js 15 app under `apps/lobby`). Lobby is the BEFORE: invite redemption, persona pick, waiting room, playtest signup. It is a **distinct surface from Pulse** (the in-game shell). Polish work in this app should NOT inherit Pulse's calm-by-default voice or its Clash + Satoshi typography. The two are intentionally different products at different moments in the player journey.
+
+For Pulse design context, see the repo-root `.impeccable.md`.
+
+## Design Context
+
+### Users
+
+Two audiences land here, often via shared invite links on phones during downtime:
+
+1. **Invitees** — getting an SMS or DM that says "join my game", tapping a `/j/CODE` link. They've never used the app. They need to instantly feel "this is a real thing my friends are into." Fast first impression matters more than any other surface.
+2. **Hosts** — friends who created a game, sharing it, watching the cast fill, kicking it off. They need confidence that the game is loaded and ready, plus quick tools to pull people in.
+
+Both groups are mostly teens / early-20s. Sessions are short (under 2 minutes for invitee onboarding; under 5 for hosts). Browser is mobile Safari or Chrome on Android. Entry context is the lock screen → notification → tap.
+
+### Brand Personality
+
+**Three-word personality**: *loud · gossipy · electric.*
+
+**Emotional goals**: anticipation, casting-call energy, "you got picked." Lobby sells the show before it starts. Where Pulse is the broadcast (calm, dramatic, recede), Lobby is the casting reel + the dressing room + the door bouncer all at once.
+
+The interface must feel:
+- **Magazine-cover loud** — type that doesn't apologize, layouts that crop hard
+- **Photo-driven** — persona portraits ARE the visual. Surfaces support them.
+- **High-energy without jitter** — motion is welcome (party energy, live-event animation), but never decorative-for-its-own-sake. Animation should mark a moment, not fill empty time.
+- **Friendly to first-touch** — invitees who've never seen the app should figure out what to do without reading
+
+### Aesthetic Direction
+
+**Theme**: Dark-first, party-warm. Deep purple → magenta → hot pink → gold. The palette is committed in `packages/ui-kit/src/theme.css` under `:root[data-theme="reality-tv"]`. Don't shift the hue family.
+
+**Visual tone**: Reality-TV title-card meets event flyer meets nightclub door. Big chunky display type, dramatic crops, gold + hot pink as the two accent moments. The lobby is allowed to be **louder than Pulse** — bounce easings, glow-breathes, scale-pulses are on-brand here when used with intention.
+
+**Positive references**:
+- Reality-TV cast-reveal title cards (bold, character-rich type, photo-led)
+- Event posters (loud type, layered crops, single-color washes)
+- Premium recruiting flows (Cameo, BeReal onboarding) — fast, photo-led, opinionated
+- Ticket-stub layouts for the share / referral surface
+
+**Anti-references**:
+- The Pulse shell (different product moment, different rules)
+- Generic AI-default landing pages: Inter + glassmorphism + drop-shadow cards + icon-above-heading templates
+- Enterprise "dashboard" aesthetic — gradient boxes, sparklines, multi-accent palettes
+- B2B SaaS empty states with cute illustrations
+
+### Design Principles
+
+1. **The cast is the visual interest.** Persona portraits carry the page. Chrome surfaces stay simple — opaque, well-bordered, no glass stacks.
+2. **Loud type, single accent at a time.** Display type does the heavy lifting. Gold is for primary signal, hot-pink for active commit. They're not used together in the same card.
+3. **Motion marks moments.** Persona arriving, button committing, badge popping in. Not infinite ambient breath on every card. One motion at a time, near the user's attention.
+4. **Mobile-first means thumb-first.** Every tap target ≥44×44. Bottom action bars use safe-area insets. Forms enable the primary button by default and validate on press, so users get feedback for every tap.
+5. **One opaque card per page.** No card-inside-a-card. No glassmorphism stacks where two blurred surfaces overlap. Either commit to opaque chrome or let the persona photograph BE the card.
+6. **Copy talks like the players do.** Section labels read like a casting board, not a settings panel. Reality-TV voice — short, punchy, teen-native. Loading and empty states get the same treatment as the rest.
+7. **Lobby is the "before."** Every surface should hint at energy building toward day 1. Static is fine; lifeless is not.
+
+## Locked Tokens (already shipped)
+
+### Color (`packages/ui-kit/src/theme.css`, `:root[data-theme="reality-tv"]`)
+- Backgrounds: deep `#2c003e` → panel `#4c1d95` → input `#5b21b6` → bubble `#3b1a7e`. Never pure black.
+- Primary signal: **gold** `#fbbf24` (`--po-gold`)
+- Active accent: **hot pink** `#ec4899` (`--po-pink`)
+- Status: green `#10b981`, danger `#ef4444`. Use sparingly.
+- Border: `rgba(255,255,255,0.1)` faint edge, gold for active.
+
+### Motion (Tailwind preset animations)
+`pulse-live`, `slide-up-in`, `glow-breathe`, `badge-pop`, `flash-update`, `count-pop`. Lobby allows these. Pulse bans some; here they're correct. Use one at a time per surface, anchor to user attention.
+
+### Icons
+Lucide icons for general iconography. Lobby is *not* tied to Pulse's Phosphor Fill choice — pick the icon that fits the moment, lean toward heavier weights for display headers.
+
+### Z-index
+No formal layering token. Modals stack above; nothing else needs invented numbers. Keep flat.
+
+## Typography (RESOLVED — this section authoritative)
+
+Lobby ships on **Big Shoulders Display** (display) + **Manrope** (body), both via Google Fonts. Mono is **JetBrains Mono**, reserved for *actual* monospace need (codes, timers, technical receipts) — not for "tech vibes" texture.
+
+- **Big Shoulders Display** — narrow, condensed, dramatic. Built for civic-monument signage. Used for `--po-font-display`: hero "PECKING ORDER" wordmark, persona names, screen titles, all caps eyebrow labels.
+- **Manrope** — geometric sans with rounded warmth, designed off Inter's defaults. Used for `--po-font-body` and the page's default `font-family`. Reads warm, modern, NOT austere or developer-coded.
+- **JetBrains Mono** — invite codes (`ABCD-EFGH`), referral codes, copy-link inputs. NOT for emails, error messages, link captions, footers.
+
+Fallback: `system-ui, sans-serif`. No Inter, no Poppins, no Outfit, no DM Sans in the stack — those are reflex fonts.
+
+### Type rules
+- Display sizes use fluid `clamp()` for headings on hero / above-the-fold copy. Fixed rem on UI labels (chips, button text, status badges).
+- 1.25+ ratio between hierarchy steps. No flat type pyramids.
+- Body line length capped ~65-75ch.
+- Cast names + screen titles are heavy weight + tight tracking. Subheads are lighter + open. No mid-weight gray text on colored backgrounds.
+
+## Production Hardening Bar
+
+Player-facing surfaces must handle:
+- **Loading states** — skeletons, never just a "Loading…" string
+- **Error states** — invalid invite, expired link, network failure, rate-limited
+- **Empty states** — first joiner, all slots empty, no invites sent yet
+- **Edge content** — long persona names (truncate gracefully, not mid-word), 280-char bios, missing portraits (image fallback already in place — keep it)
+- **Disabled states** — replace where possible with enabled + validation-on-press
+- **Network failures** — server actions wrapped, errors surfaced in line, no silent swallows
+- **Reduced motion** — `useReducedMotion` respected on entrance animations and ambient loops
+- **Cross-device** — touch ≥44×44, `dvh` (not `vh`) for full-height containers, safe-area insets on top + bottom action bars, soft-keyboard doesn't crop primary CTAs
+- **Image graceful degradation** — `onError` fallback already in use, keep it; below-the-fold portraits lazy-loaded
+
+## References
+
+- `apps/lobby/app/j/[code]/page.tsx` — frictionless welcome (the first-impression surface)
+- `apps/lobby/app/join/[code]/page.tsx` — 4-step persona wizard (highest-stakes, most-shipped UX)
+- `apps/lobby/app/game/[id]/waiting/page.tsx` — pre-game lobby + cast grid + host invite
+- `apps/lobby/app/login/page.tsx` — email entry / magic-link send
+- `apps/lobby/app/playtest/page.tsx` — public signup hub (recruitment)
+- `packages/ui-kit/src/theme.css` — locked color + motion tokens
+- `packages/ui-kit/src/tailwind-preset.js` — `skin-*` color/text/border classes, animation keyframes
+- `apps/lobby/CLAUDE.md` — app-level conventions (PII, slot indexing)

--- a/apps/lobby/app/game/[id]/waiting/page.tsx
+++ b/apps/lobby/app/game/[id]/waiting/page.tsx
@@ -120,23 +120,89 @@ export default function WaitingRoom() {
       ? `${window.location.origin}/j/${code.toUpperCase()}`
       : '';
 
-  async function handleCopyLink() {
+  // Brand mantra echoed in every host-share. Recipients see the verb stack
+  // before the URL — the same hook they'd see if they tapped the link and
+  // unfurled in iMessage. Repetition is the point.
+  const shareText = `Vote. Ally. Betray. Survive. I’m running a Pecking Order game — you’re cast.`;
+
+  // Robust clipboard write — `navigator.clipboard` is unavailable in
+  // non-secure contexts (some embedded browsers, older iOS in-app webviews)
+  // and rejects silently when the document isn't focused.
+  async function writeClipboard(text: string): Promise<boolean> {
     try {
-      await navigator.clipboard.writeText(shareLink);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+        return true;
+      }
     } catch {
-      // Fallback for older browsers
-      const textarea = document.createElement('textarea');
-      textarea.value = shareLink;
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
+      // fall through
+    }
+    try {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.setAttribute('readonly', '');
+      ta.style.position = 'absolute';
+      ta.style.left = '-9999px';
+      document.body.appendChild(ta);
+      ta.select();
+      const ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      return ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async function handleCopyLink() {
+    const ok = await writeClipboard(shareLink);
+    if (ok) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     }
   }
+
+  // Native Web Share API — preferred when available because the OS share
+  // sheet covers iMessage/WhatsApp/Messenger/etc without us hard-coding each.
+  // AbortError = user dismissed the sheet (deliberate cancel, not a failure).
+  async function handleNativeShare() {
+    if (typeof navigator === 'undefined' || typeof navigator.share !== 'function') {
+      handleCopyLink();
+      return;
+    }
+    try {
+      await navigator.share({
+        title: 'Pecking Order',
+        text: shareText,
+        url: shareLink,
+      });
+    } catch (err) {
+      if ((err as DOMException)?.name === 'AbortError') return;
+      // Share-sheet open failed — fall back to copy so the host doesn't lose
+      // the invite link to the void.
+      handleCopyLink();
+    }
+  }
+
+  function handleSmsShare() {
+    // sms:?&body= is the cross-platform form (iOS + Android both honor it).
+    window.location.href = `sms:?&body=${encodeURIComponent(`${shareText} ${shareLink}`)}`;
+  }
+
+  function handleWhatsAppShare() {
+    // WA renders \n as visual line breaks — stack mantra over URL for
+    // a poster-shaped chat preview.
+    const text = `${shareText}\n\n${shareLink}`;
+    const url = `https://wa.me/?text=${encodeURIComponent(text)}`;
+    const win = window.open(url, '_blank', 'noopener,noreferrer');
+    if (!win) window.location.href = url;
+  }
+
+  // Native share is rare on desktop, common on mobile. Capture once on
+  // mount so the button row doesn't ship and immediately disappear.
+  const [hasNativeShare, setHasNativeShare] = useState(false);
+  useEffect(() => {
+    setHasNativeShare(typeof navigator !== 'undefined' && typeof navigator.share === 'function');
+  }, []);
 
   const filledSlots = slots.filter((s) => s.acceptedBy);
   const emptySlots = slots.filter((s) => !s.acceptedBy);
@@ -154,7 +220,7 @@ export default function WaitingRoom() {
   const bgPersonaId = myPersonaId || filledSlots[0]?.personaId;
 
   return (
-    <div className="h-screen h-dvh flex flex-col bg-skin-deep bg-grid-pattern font-body text-skin-base relative selection:bg-skin-gold/30 overflow-hidden">
+    <div className="h-dvh flex flex-col bg-skin-deep bg-grid-pattern font-body text-skin-base relative selection:bg-skin-gold/30 overflow-hidden">
       {/* Blurred persona background */}
       <AnimatePresence mode="popLayout">
         {bgPersonaId && (
@@ -182,11 +248,11 @@ export default function WaitingRoom() {
           <h1 className="text-3xl md:text-5xl font-display font-black tracking-tighter text-skin-gold text-glow">
             PECKING ORDER
           </h1>
-          <p className="text-sm text-skin-dim font-mono">
-            Game: <span className="text-skin-gold font-bold tracking-wider">{code.toUpperCase()}</span>
+          <p className="text-sm text-skin-dim">
+            Game: <span className="text-skin-gold font-mono font-bold tracking-wider">{code.toUpperCase()}</span>
           </p>
-          <div className="mt-2 max-w-sm mx-auto space-y-1.5">
-            <div className="text-[10px] font-bold text-skin-dim uppercase tracking-widest text-left">
+          <div className="mt-2 max-w-sm mx-auto space-y-2">
+            <div className="text-[10px] font-display font-bold text-skin-dim uppercase tracking-widest text-left">
               Invite link
             </div>
             <div className="flex items-center gap-2 p-2 rounded-lg bg-skin-input/60">
@@ -195,9 +261,54 @@ export default function WaitingRoom() {
               </code>
               <button
                 onClick={handleCopyLink}
-                className="text-xs font-bold text-skin-gold px-2 py-1 rounded border border-skin-gold/30 hover:border-skin-gold/60 transition-all whitespace-nowrap"
+                aria-label={copied ? 'Invite link copied' : 'Copy invite link'}
+                className="min-h-[36px] text-xs font-display font-bold text-skin-gold px-3 py-2 rounded border border-skin-gold/30 hover:border-skin-gold/60 transition-all whitespace-nowrap"
               >
                 {copied ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+
+            {/* Per-channel share row — sits below the link copy. On mobile,
+                the native-share button leads (opens the OS share sheet,
+                which covers iMessage/WhatsApp/Discord/etc in one tap). On
+                desktop where the Web Share API is rare, SMS + WhatsApp
+                shortcuts pick up the slack. Mantra-led text in every
+                channel so unfurls and chat previews carry the brand. */}
+            <div className="flex gap-2 pt-1">
+              {hasNativeShare && (
+                <button
+                  onClick={handleNativeShare}
+                  className="flex-1 min-h-[40px] inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-skin-pink text-skin-base text-xs font-display font-bold uppercase tracking-widest hover:brightness-110 active:scale-[0.99] transition-all"
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                    <circle cx="18" cy="5" r="3" />
+                    <circle cx="6" cy="12" r="3" />
+                    <circle cx="18" cy="19" r="3" />
+                    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+                    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+                  </svg>
+                  Share
+                </button>
+              )}
+              <button
+                onClick={handleSmsShare}
+                aria-label="Share via SMS"
+                className={`${hasNativeShare ? 'w-10' : 'flex-1'} min-h-[40px] inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-[#22c55e] text-white text-xs font-display font-bold uppercase tracking-widest hover:brightness-110 active:scale-[0.99] transition-all`}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                  <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+                </svg>
+                {!hasNativeShare && <span>SMS</span>}
+              </button>
+              <button
+                onClick={handleWhatsAppShare}
+                aria-label="Share via WhatsApp"
+                className={`${hasNativeShare ? 'w-10' : 'flex-1'} min-h-[40px] inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-[#25D366] text-white text-xs font-display font-bold uppercase tracking-widest hover:brightness-110 active:scale-[0.99] transition-all`}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                  <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+                </svg>
+                {!hasNativeShare && <span>WhatsApp</span>}
               </button>
             </div>
           </div>
@@ -206,42 +317,40 @@ export default function WaitingRoom() {
         {/* Status badge */}
         <div className="flex justify-center mt-2 flex-shrink-0">
           <motion.div
+            role="status"
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ delay: 0.2, duration: 0.3 }}
-            className={`inline-flex items-center gap-2 px-4 py-2 rounded-full backdrop-blur-sm text-xs font-mono font-bold uppercase tracking-widest
+            className={`inline-flex items-center gap-2 px-4 py-2 rounded-full bg-skin-deep/60 text-xs font-display font-bold uppercase tracking-widest border
               ${
                 isStarted
-                  ? 'text-skin-green'
+                  ? 'text-skin-green border-skin-green'
                   : isReady
-                    ? 'text-skin-gold'
-                    : 'text-skin-dim'
+                    ? 'text-skin-gold border-skin-gold'
+                    : 'text-skin-dim border-skin-base'
               }`}
-            style={{
-              backgroundColor: 'rgba(44, 0, 62, 0.6)',
-              border: `1px solid ${isStarted ? 'var(--po-green)' : isReady ? 'var(--po-gold)' : 'var(--po-border)'}`,
-            }}
           >
             <span
               className={`w-2 h-2 rounded-full ${
                 isStarted ? 'bg-skin-green' : isReady ? 'bg-skin-gold' : 'bg-skin-dim'
               } ${!isStarted ? 'animate-pulse' : ''}`}
+              aria-hidden
             />
             {isStarted
               ? 'Game Started'
               : isReady
                 ? 'Ready to Launch'
                 : isLoading
-                  ? 'Loading...'
+                  ? 'Cueing the room…'
                   : `Waiting for Players (${filledSlots.length}/${totalSlots})`}
           </motion.div>
         </div>
 
         {/* Cast title */}
         <div className="text-center mt-2 flex-shrink-0">
-          <div className="text-base font-display font-black text-skin-gold text-glow uppercase tracking-widest">
+          <h2 className="text-base font-display font-black text-skin-gold text-glow uppercase tracking-widest">
             The Cast
-          </div>
+          </h2>
         </div>
 
         {/* Cast grid */}
@@ -260,51 +369,58 @@ export default function WaitingRoom() {
               transition={{ duration: 0.4 }}
               className="grid grid-cols-2 gap-3"
             >
-              {/* Filled slots — cast portrait cards */}
-              {filledSlots.map((slot, idx) => (
-                <motion.div
-                  key={slot.slotIndex}
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: idx * 0.08, duration: 0.35 }}
-                  className="aspect-[3/4] relative rounded-2xl overflow-hidden glow-breathe"
-                >
-                  {slot.personaId ? (
-                    <img
-                      src={personaMediumUrl(slot.personaId)}
-                      alt={slot.personaName || ''}
-                      className="absolute inset-0 w-full h-full object-cover object-top"
-                    />
-                  ) : (
-                    <div className="absolute inset-0 bg-skin-input" />
-                  )}
-                  {/* Gradient overlay */}
-                  <div className="absolute inset-0 bg-gradient-to-t from-skin-deep via-skin-deep/40 via-30% to-transparent pointer-events-none" />
-                  {/* Name + stereotype */}
-                  <div className="absolute bottom-0 left-0 right-0 p-3 pointer-events-none">
-                    <div className="text-sm font-display font-black text-skin-base text-glow leading-tight truncate">
-                      {slot.personaName}
+              {/* Filled slots — cast portrait cards. Only the most-recent join
+                  (last in the list) gets the breathing glow, so the eye lands
+                  on what just happened instead of every card competing. */}
+              {filledSlots.map((slot, idx) => {
+                const isMostRecent = idx === filledSlots.length - 1;
+                return (
+                  <motion.div
+                    key={slot.slotIndex}
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ delay: idx * 0.08, duration: 0.35 }}
+                    className={`aspect-[3/4] relative rounded-2xl overflow-hidden ${isMostRecent ? 'glow-breathe' : ''}`}
+                  >
+                    {slot.personaId ? (
+                      <img
+                        src={personaMediumUrl(slot.personaId)}
+                        alt={slot.personaName || ''}
+                        loading={idx < 4 ? 'eager' : 'lazy'}
+                        className="absolute inset-0 w-full h-full object-cover object-top"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 bg-skin-input" />
+                    )}
+                    {/* Gradient overlay */}
+                    <div className="absolute inset-0 bg-gradient-to-t from-skin-deep via-skin-deep/40 via-30% to-transparent pointer-events-none" />
+                    {/* Name + stereotype */}
+                    <div className="absolute bottom-0 left-0 right-0 p-3 pointer-events-none">
+                      <div className="text-sm font-display font-black text-skin-base text-glow leading-tight truncate">
+                        {slot.personaName}
+                      </div>
+                      <div className="text-[9px] font-display font-bold text-skin-gold uppercase tracking-[0.15em] truncate">
+                        {slot.personaStereotype}
+                      </div>
                     </div>
-                    <div className="text-[9px] font-display font-bold text-skin-gold uppercase tracking-[0.15em] truncate">
-                      {slot.personaStereotype}
-                    </div>
-                  </div>
-                </motion.div>
-              ))}
+                  </motion.div>
+                );
+              })}
 
-              {/* Empty slots — mysterious placeholders */}
+              {/* Empty slots — casting-call placeholder, not "TBD" project-status. */}
               {emptySlots.map((slot) => (
                 <motion.div
                   key={slot.slotIndex}
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   transition={{ delay: filledSlots.length * 0.08 + 0.1, duration: 0.3 }}
-                  className="aspect-[3/4] relative rounded-2xl overflow-hidden border border-dashed flex items-center justify-center"
-                  style={{ borderColor: 'rgba(255,255,255,0.1)', backgroundColor: 'rgba(44, 0, 62, 0.4)' }}
+                  className="aspect-[3/4] relative rounded-2xl overflow-hidden border border-dashed border-skin-base/40 bg-skin-deep/40 flex items-center justify-center"
                 >
-                  <div className="text-center space-y-2">
-                    <div className="text-4xl text-skin-dim/20 animate-pulse">?</div>
-                    <div className="text-[10px] font-mono text-skin-dim/30 uppercase tracking-widest">TBD</div>
+                  <div className="text-center space-y-1">
+                    <div className="text-[10px] font-display font-bold text-skin-faint uppercase tracking-[0.2em]">
+                      Open seat
+                    </div>
+                    <div className="text-xs text-skin-faint/70">Waiting on someone</div>
                   </div>
                 </motion.div>
               ))}
@@ -317,8 +433,8 @@ export default function WaitingRoom() {
             <div className="mt-4">
               <button
                 onClick={() => setShowInviteSection(!showInviteSection)}
-                className="w-full flex items-center justify-between py-3 px-4 rounded-xl border border-skin-base/50 backdrop-blur-sm text-sm font-display font-bold text-skin-dim hover:text-skin-base hover:border-skin-gold/30 transition-all"
-                style={{ backgroundColor: 'rgba(44, 0, 62, 0.5)' }}
+                aria-expanded={showInviteSection}
+                className="w-full flex items-center justify-between py-3 px-4 rounded-xl border border-skin-base/50 bg-skin-deep/50 text-sm font-display font-bold text-skin-dim hover:text-skin-base hover:border-skin-gold/30 transition-all"
               >
                 <span>Invite by Email</span>
                 <svg
@@ -345,18 +461,21 @@ export default function WaitingRoom() {
                       <form onSubmit={handleSendInvite} className="flex gap-2">
                         <input
                           type="email"
+                          inputMode="email"
+                          autoComplete="off"
                           value={inviteEmail}
                           onChange={(e) => setInviteEmail(e.target.value)}
                           placeholder="player@example.com"
+                          aria-label="Player email"
                           required
-                          className="flex-1 bg-skin-input text-skin-base border border-skin-base rounded-lg px-3 py-2.5 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 placeholder:text-skin-dim/30"
+                          className="flex-1 bg-skin-input text-skin-base border border-skin-base rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 placeholder:text-skin-faint"
                         />
                         <button
                           type="submit"
                           disabled={isSendingInvite || !inviteEmail.trim()}
                           className={`px-4 py-2.5 rounded-lg font-display font-bold text-xs uppercase tracking-widest transition-all whitespace-nowrap
                             ${isSendingInvite || !inviteEmail.trim()
-                              ? 'bg-skin-input text-skin-dim/40 cursor-wait'
+                              ? 'bg-skin-input text-skin-faint cursor-wait'
                               : 'bg-skin-gold text-skin-deep hover:brightness-110 active:scale-[0.98]'
                             }`}
                         >
@@ -365,30 +484,29 @@ export default function WaitingRoom() {
                       </form>
 
                       {inviteStatus && (
-                        <div className="p-2.5 rounded-lg bg-skin-green/10 border border-skin-green/30 text-skin-green text-xs font-mono text-center">
+                        <div role="status" className="p-2.5 rounded-lg bg-skin-green/10 border border-skin-green/30 text-skin-green text-xs text-center">
                           {inviteStatus}
                         </div>
                       )}
 
                       {inviteError && (
-                        <div className="p-2.5 rounded-lg bg-skin-pink/10 border border-skin-pink/30 text-skin-pink text-xs font-mono text-center">
+                        <div role="alert" className="p-2.5 rounded-lg bg-skin-pink/10 border border-skin-pink/30 text-skin-pink text-xs text-center">
                           {inviteError}
                         </div>
                       )}
 
                       {sentInvites.length > 0 && (
                         <div className="space-y-1.5">
-                          <div className="text-[10px] font-mono text-skin-dim/50 uppercase tracking-widest px-1">
+                          <div className="text-[10px] font-display font-bold text-skin-faint uppercase tracking-widest px-1">
                             Sent Invites
                           </div>
                           {sentInvites.map((inv) => (
                             <div
                               key={inv.email + inv.createdAt}
-                              className="flex items-center justify-between py-1.5 px-3 rounded-lg text-xs font-mono"
-                              style={{ backgroundColor: 'rgba(44, 0, 62, 0.4)' }}
+                              className="flex items-center justify-between py-1.5 px-3 rounded-lg text-xs bg-skin-deep/40"
                             >
                               <span className="text-skin-dim truncate">{inv.email}</span>
-                              <span className={`text-[10px] uppercase tracking-wider ${inv.used ? 'text-skin-green' : 'text-skin-dim/40'}`}>
+                              <span className={`text-[10px] font-display font-bold uppercase tracking-wider ${inv.used ? 'text-skin-green' : 'text-skin-faint'}`}>
                                 {inv.used ? 'Joined' : 'Pending'}
                               </span>
                             </div>
@@ -408,7 +526,7 @@ export default function WaitingRoom() {
       <div className="flex-shrink-0 relative z-20 bg-gradient-to-b from-skin-deep/0 to-skin-deep pt-3 px-4" style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}>
         <div className="max-w-lg mx-auto">
           {error && (
-            <div className="p-3 mb-3 rounded-lg bg-skin-pink/10 border border-skin-pink/30 text-skin-pink text-sm font-mono text-center">
+            <div role="alert" className="p-3 mb-3 rounded-lg bg-skin-pink/10 border border-skin-pink/30 text-skin-pink text-sm text-center">
               {error}
             </div>
           )}
@@ -428,7 +546,7 @@ export default function WaitingRoom() {
                   className={`w-full py-4 font-display font-bold text-sm tracking-widest uppercase rounded-xl shadow-lg transition-all flex items-center justify-center gap-3
                     ${
                       isStarting
-                        ? 'bg-skin-input text-skin-dim/40 cursor-wait'
+                        ? 'bg-skin-input text-skin-faint cursor-wait'
                         : 'bg-skin-pink text-skin-base shadow-btn hover:brightness-110 active:scale-[0.99]'
                     }`}
                 >
@@ -455,7 +573,7 @@ export default function WaitingRoom() {
                 className="space-y-3"
               >
                 {pushSent && (
-                  <div className="p-3 rounded-lg bg-skin-green/10 border border-skin-green/30 text-skin-green text-xs font-mono text-center">
+                  <div role="status" className="p-3 rounded-lg bg-skin-green/10 border border-skin-green/30 text-skin-green text-xs text-center">
                     We sent a notification to your app. Tap it to enter!
                   </div>
                 )}
@@ -579,8 +697,8 @@ export default function WaitingRoom() {
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.15 }}
               >
-                <p className="text-center text-xs text-skin-dim font-mono">
-                  Share the invite code and refresh when everyone has joined.
+                <p className="text-center text-xs text-skin-dim">
+                  Share the invite code. We'll refresh when everyone joins.
                 </p>
               </motion.div>
             )}
@@ -593,7 +711,7 @@ export default function WaitingRoom() {
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.15 }}
               >
-                <p className="text-center text-xs text-skin-dim font-mono">
+                <p className="text-center text-xs text-skin-dim">
                   Share the invite code. You can enter the game while waiting for other players.
                 </p>
               </motion.div>

--- a/apps/lobby/app/j/[code]/joined-cast.tsx
+++ b/apps/lobby/app/j/[code]/joined-cast.tsx
@@ -57,7 +57,7 @@ export function JoinedCast({
                     delay: 0.05 + i * 0.08,
                   }
             }
-            className={`relative w-[84px] h-[120px] sm:w-[110px] sm:h-[156px] rounded-[14px] overflow-hidden shadow-[0_12px_40px_rgba(0,0,0,0.55)] ring-1 ring-white/5 ${overlapClass}`}
+            className={`relative w-[84px] h-[120px] sm:w-[110px] sm:h-[156px] rounded-[14px] overflow-hidden shadow-card ring-1 ring-white/5 ${overlapClass}`}
             style={{
               // Neutral dark fill behind the image. If the CDN 404s the
               // onError handler below hides the <img>, leaving this fill

--- a/apps/lobby/app/j/[code]/page.tsx
+++ b/apps/lobby/app/j/[code]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import { getDB, getEnv } from '@/lib/db';
 import { getSession } from '@/lib/auth';
@@ -7,6 +8,69 @@ import { buildSocialLine, displayLabelFor, type JoinedPlayer } from './cast-help
 
 interface PageProps {
   params: Promise<{ code: string }>;
+}
+
+// Per-link OG metadata. The previous behavior fell through to the root
+// layout's "Pecking Order — A social game of..." generic copy, so every
+// invite link unfurled identically in iMessage / WhatsApp / Discord
+// regardless of who sent it. This generates a contextual unfurl card per
+// invite: when the host's persona is known, name it; otherwise lean on
+// the brand mantra. Always falls back gracefully — if the game/code
+// doesn't exist, the page itself 404s and the unfurl never matters.
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { code } = await params;
+  const env = await getEnv();
+  const lobbyHost = (env.LOBBY_HOST as string) || 'https://lobby.peckingorder.ca';
+  const ogImage = `${lobbyHost}/og-playtest.png`;
+
+  let hostLabel: string | null = null;
+  try {
+    const db = await getDB();
+    // Host = the persona who created the game. Pull their persona name for
+    // unfurl context. One lightweight query at metadata time; runs in
+    // parallel with page rendering on the same request.
+    const row = await db
+      .prepare(
+        `SELECT pp.name AS persona_name
+         FROM GameSessions gs
+         INNER JOIN Invites i ON i.game_id = gs.id AND i.accepted_by = gs.host_user_id
+         LEFT JOIN PersonaPool pp ON pp.id = i.persona_id
+         WHERE gs.invite_code = ?
+         LIMIT 1`,
+      )
+      .bind(code.toUpperCase())
+      .first<{ persona_name: string | null }>();
+    hostLabel = row?.persona_name ?? null;
+  } catch {
+    // DB failure shouldn't block metadata. Fall back to mantra-only copy.
+  }
+
+  const title = hostLabel
+    ? `${hostLabel} added you to Pecking Order`
+    : `You're invited to Pecking Order`;
+  const description = 'Vote. Ally. Betray. Survive. A social deduction game in your group chat. Seven days. One winner.';
+  const url = `${lobbyHost}/j/${code.toUpperCase()}`;
+
+  return {
+    metadataBase: new URL(lobbyHost),
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: 'Pecking Order',
+      images: [{ url: ogImage, width: 1200, height: 630, alt: 'Pecking Order — Vote. Ally. Betray. Survive.' }],
+      type: 'website',
+      locale: 'en_US',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
+  };
 }
 
 export default async function FrictionlessWelcomePage({ params }: PageProps) {
@@ -124,9 +188,9 @@ export default async function FrictionlessWelcomePage({ params }: PageProps) {
         )}
 
         <header className="text-center space-y-3">
-          <div className="text-[10px] font-display font-bold text-skin-accent uppercase tracking-[0.3em]">
+          <p className="text-[10px] font-display font-bold text-skin-gold uppercase tracking-[0.3em]">
             Pecking Order
-          </div>
+          </p>
           <h1
             className="font-display font-black text-skin-base leading-[0.95]"
             // Fluid headline — 2rem on ~320px phones, 3.25rem on tablets+.
@@ -139,7 +203,29 @@ export default async function FrictionlessWelcomePage({ params }: PageProps) {
           </p>
         </header>
 
+        {/* Brand verb-stack — only on the empty state. With cast present, the
+            JoinedCast component IS the visual interest; the verb stack here
+            would compete. With no cast, the page would otherwise be a logo
+            + headline + form — the stack fills that void with the same brand
+            mantra used on /playtest and in invite emails. */}
+        {!hasCast && (
+          <div
+            aria-hidden
+            className="text-center font-display font-black uppercase leading-[0.92] tracking-tight"
+            style={{ fontSize: 'clamp(2.25rem, 10vw, 3.5rem)' }}
+          >
+            <div className="text-skin-base">Vote.</div>
+            <div className="text-skin-gold">Ally.</div>
+            <div className="text-skin-base">Betray.</div>
+            <div className="text-skin-pink">Survive.</div>
+          </div>
+        )}
+
         <WelcomeForm code={game.invite_code} />
+
+        <p className="text-center text-[11px] text-skin-dim tracking-wide">
+          Seven days. One winner. Don’t get voted out.
+        </p>
       </div>
     </div>
   );

--- a/apps/lobby/app/j/[code]/welcome-form.tsx
+++ b/apps/lobby/app/j/[code]/welcome-form.tsx
@@ -11,6 +11,10 @@ export function WelcomeForm({ code }: { code: string }) {
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
+    if (handle.trim().length === 0) {
+      setError('Name your character first.');
+      return;
+    }
     startTransition(async () => {
       const result = await claimSeat(code, handle);
       if (!result.ok) {
@@ -19,7 +23,7 @@ export function WelcomeForm({ code }: { code: string }) {
             setError('Name must be 1-24 characters.');
             break;
           case 'rate_limited':
-            setError('Too many attempts from this network. Try again later.');
+            setError('Too many tries from this network. Give it a sec.');
             break;
           case 'game_not_found':
             setError('Game not found.');
@@ -28,7 +32,7 @@ export function WelcomeForm({ code }: { code: string }) {
             setError('This game already started.');
             break;
           default:
-            setError('Something went wrong. Try again.');
+            setError('Something went sideways. Try again.');
         }
       }
       // Success: the server action redirected, this callback never reaches here.
@@ -36,9 +40,9 @@ export function WelcomeForm({ code }: { code: string }) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-4" noValidate>
       <label className="block">
-        <span className="text-xs font-bold text-skin-dim uppercase tracking-widest">
+        <span className="block text-xs font-bold text-skin-dim uppercase tracking-widest">
           What should we call you?
         </span>
         <input
@@ -46,11 +50,12 @@ export function WelcomeForm({ code }: { code: string }) {
           value={handle}
           onChange={(e) => setHandle(e.target.value)}
           autoFocus
+          autoComplete="given-name"
           maxLength={24}
           placeholder="Your name"
-          className="mt-2 w-full px-4 py-3 bg-skin-input border border-skin-base rounded-xl text-skin-base placeholder:text-skin-dim/40 focus:outline-none focus:border-skin-gold/50"
+          className="mt-2 w-full px-4 py-3 bg-skin-input border border-skin-base rounded-xl text-skin-base placeholder:text-skin-dim/70 focus:outline-none focus:border-skin-gold/50 text-base"
         />
-        <span className="mt-2 block text-[11px] text-skin-dim/60">
+        <span className="mt-2 block text-[11px] text-skin-dim">
           This is so the group knows you in-game and in the reveal at the end.
         </span>
       </label>
@@ -66,8 +71,9 @@ export function WelcomeForm({ code }: { code: string }) {
 
       <button
         type="submit"
-        disabled={isPending || handle.trim().length === 0}
-        className="w-full py-4 bg-skin-gold text-skin-deep font-display font-black text-sm uppercase tracking-widest rounded-xl disabled:opacity-40"
+        disabled={isPending}
+        aria-busy={isPending}
+        className="w-full min-h-[52px] py-4 bg-skin-gold text-skin-deep font-display font-black text-sm uppercase tracking-widest rounded-xl disabled:opacity-50 active:scale-[0.99] transition-transform"
       >
         {isPending ? 'Joining…' : "Let's go →"}
       </button>

--- a/apps/lobby/app/join/[code]/QuestionStep.tsx
+++ b/apps/lobby/app/join/[code]/QuestionStep.tsx
@@ -62,10 +62,10 @@ export function QuestionStep({ questions, personaName, onComplete, onSkip }: Que
     <div className="h-full flex flex-col">
       {/* Header */}
       <div className="text-center flex-shrink-0 space-y-1">
-        <div className="text-base font-display font-black text-skin-gold text-glow uppercase tracking-widest">
+        <h2 className="text-base font-display font-black text-skin-gold text-glow uppercase tracking-widest">
           Get Into Character
-        </div>
-        <p className="text-xs text-skin-dim/60">
+        </h2>
+        <p className="text-xs text-skin-dim">
           Answer as <span className="text-skin-gold font-bold">{personaName}</span> — or{' '}
           <button
             onClick={onSkip}
@@ -108,8 +108,8 @@ export function QuestionStep({ questions, personaName, onComplete, onSkip }: Que
             >
               {/* Question text */}
               <div className="text-center px-2">
-                <span className="text-xs font-mono text-skin-dim/40">
-                  {currentIndex + 1}/{questions.length}
+                <span className="text-xs font-display font-bold text-skin-dim tracking-widest tabular-nums">
+                  {currentIndex + 1} / {questions.length}
                 </span>
                 <h2 className="text-lg font-display font-bold text-skin-base mt-1 leading-snug">
                   {question.text}
@@ -131,7 +131,7 @@ export function QuestionStep({ questions, personaName, onComplete, onSkip }: Que
                           : 'bg-skin-panel/30 border border-skin-base/30 text-skin-base hover:bg-skin-panel/50'
                       }`}
                     >
-                      <span className="text-skin-dim/40 font-mono text-xs mr-2">
+                      <span className="text-skin-dim font-display font-bold text-xs mr-2">
                         {String.fromCharCode(65 + idx)}.
                       </span>
                       {option}
@@ -146,7 +146,7 @@ export function QuestionStep({ questions, personaName, onComplete, onSkip }: Que
                     : 'bg-skin-panel/30 border border-skin-base/30'
                 }`}>
                   <div className="flex items-center gap-2 px-4 py-2">
-                    <span className="text-skin-dim/40 font-mono text-xs">D.</span>
+                    <span className="text-skin-dim font-display font-bold text-xs">D.</span>
                     <input
                       type="text"
                       value={currentSub?.selectedIndex === 3 ? (currentSub.customAnswer ?? '') : customText}
@@ -162,7 +162,8 @@ export function QuestionStep({ questions, personaName, onComplete, onSkip }: Que
                         }
                       }}
                       placeholder="Write your own..."
-                      className="flex-1 bg-transparent text-sm text-skin-base placeholder:text-skin-dim/40 focus:outline-none"
+                      aria-label="Custom answer"
+                      className="flex-1 bg-transparent text-sm text-skin-base placeholder:text-skin-dim/70 focus:outline-none"
                       maxLength={140}
                     />
                     {customText.trim() && currentSub?.selectedIndex !== 3 && (
@@ -188,7 +189,7 @@ export function QuestionStep({ questions, personaName, onComplete, onSkip }: Que
           animate={{ opacity: 1, y: 0 }}
           className="flex-shrink-0 pt-2 space-y-1"
         >
-          <p className="text-center text-xs text-skin-dim/50 font-mono">
+          <p className="text-center text-xs text-skin-dim">
             {allAnswered ? 'All done!' : `${totalAnswered}/${questions.length} answered — unanswered use defaults`}
           </p>
           <button

--- a/apps/lobby/app/join/[code]/page.tsx
+++ b/apps/lobby/app/join/[code]/page.tsx
@@ -196,8 +196,8 @@ export default function InvitePage() {
 
   if (isLoading) {
     return (
-      <div className="h-screen h-dvh bg-skin-deep bg-grid-pattern flex items-center justify-center font-body text-skin-base">
-        <div className="text-skin-dim font-mono text-sm animate-pulse">Loading...</div>
+      <div className="h-dvh bg-skin-deep bg-grid-pattern flex items-center justify-center font-body text-skin-base">
+        <div className="text-skin-dim text-sm animate-pulse">Pulling your cast…</div>
       </div>
     );
   }
@@ -233,7 +233,7 @@ export default function InvitePage() {
   const bgConfig = STEP_BG[step] || STEP_BG[1];
 
   return (
-    <div className="h-screen h-dvh flex flex-col bg-skin-deep bg-grid-pattern font-body text-skin-base relative selection:bg-skin-gold/30 overflow-hidden">
+    <div className="h-dvh flex flex-col bg-skin-deep bg-grid-pattern font-body text-skin-base relative selection:bg-skin-gold/30 overflow-hidden">
       {/* Blurred full-body background — crossfades with persona, blur/opacity varies by step */}
       <AnimatePresence mode="popLayout">
         {bgPersona && (
@@ -251,7 +251,10 @@ export default function InvitePage() {
           />
         )}
       </AnimatePresence>
-      <div className="absolute inset-0 bg-skin-deep/60 pointer-events-none" />
+      {/* Page-bg overlay over the blurred persona photo. Bumped from /60
+          to /72 so text-skin-faint and text-skin-dim hit ≥4.5:1 even when
+          the photo behind is light (faces, gold-toned wardrobe, etc.). */}
+      <div className="absolute inset-0 bg-skin-deep/72 pointer-events-none" />
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-gradient-radial from-skin-panel/40 to-transparent opacity-60 pointer-events-none" />
 
       {/* Content area — fills viewport above the bottom bar */}
@@ -261,8 +264,8 @@ export default function InvitePage() {
           <h1 className="text-3xl md:text-5xl font-display font-black tracking-tighter text-skin-gold text-glow">
             PECKING ORDER
           </h1>
-          <p className="text-sm text-skin-dim font-mono">
-            Invite Code: <span className="text-skin-gold font-bold tracking-wider">{code}</span>
+          <p className="text-sm text-skin-dim">
+            Invite Code: <span className="text-skin-gold font-mono font-bold tracking-wider">{code}</span>
           </p>
         </header>
 
@@ -286,18 +289,23 @@ export default function InvitePage() {
         {/* Character Select Wizard */}
         {!alreadyJoined && game.status === 'RECRUITING' && (
           <div className="flex-1 min-h-0 flex flex-col pt-2 gap-2">
-            {/* Step indicator — fixed, animated fill bars */}
-            <div className="flex items-center justify-center flex-shrink-0">
+            {/* Step indicator — pips at 44×44 hit area, 36×36 visible disc. */}
+            <nav aria-label="Wizard progress" className="flex items-center justify-center flex-shrink-0 -mx-0.5">
               {[1, 2, 3, 4].map((s) => (
                 <div key={s} className="flex items-center">
                   <div
-                    className={`w-8 h-8 rounded-full flex items-center justify-center text-xs font-display font-bold transition-all duration-300
-                      ${step >= s ? 'bg-skin-gold text-skin-deep' : 'bg-skin-input text-skin-dim/40'}`}
+                    className="w-11 h-11 flex items-center justify-center"
+                    aria-current={step === s ? 'step' : undefined}
                   >
-                    {step > s ? '\u2713' : s}
+                    <div
+                      className={`w-9 h-9 rounded-full flex items-center justify-center text-xs font-display font-bold transition-all duration-300
+                        ${step >= s ? 'bg-skin-gold text-skin-deep' : 'bg-skin-input text-skin-faint'}`}
+                    >
+                      {step > s ? '\u2713' : s}
+                    </div>
                   </div>
                   {s < 4 && (
-                    <div className="w-10 h-0.5 bg-skin-input relative overflow-hidden">
+                    <div className="w-8 h-0.5 bg-skin-input relative overflow-hidden">
                       <motion.div
                         className="absolute inset-0 bg-skin-gold origin-left"
                         animate={{ scaleX: step > s ? 1 : 0 }}
@@ -307,7 +315,7 @@ export default function InvitePage() {
                   )}
                 </div>
               ))}
-            </div>
+            </nav>
 
             {/* Step content — slides left/right on step change */}
             <div className="flex-1 min-h-0 relative overflow-hidden">
@@ -324,10 +332,13 @@ export default function InvitePage() {
                     transition={SPRING_SWIPE}
                     className="h-full flex flex-col gap-3"
                   >
-                    <div className="text-center flex-shrink-0">
-                      <div className="text-base font-display font-black text-skin-gold text-glow uppercase tracking-widest">
+                    <div className="text-center flex-shrink-0 space-y-1">
+                      <h2 className="text-base font-display font-black text-skin-gold text-glow uppercase tracking-widest">
                         Choose Your Persona
-                      </div>
+                      </h2>
+                      <p className="text-[11px] text-skin-dim tracking-wide">
+                        Swipe to browse. Tap one to lock in.
+                      </p>
                     </div>
 
                     {isDrawing || personas.length === 0 ? (
@@ -398,7 +409,7 @@ export default function InvitePage() {
                                 <div className="text-xs font-display font-bold text-skin-gold uppercase tracking-[0.2em]">
                                   {activePersona?.stereotype}
                                 </div>
-                                <p className="text-sm text-skin-dim/80 leading-snug pt-1">
+                                <p className="text-sm text-skin-base/90 leading-snug pt-1">
                                   {activePersona?.description}
                                 </p>
                               </div>
@@ -408,23 +419,27 @@ export default function InvitePage() {
                           {activeIndex > 0 && (
                             <button
                               onClick={() => setActiveIndex((i) => i - 1)}
-                              className="absolute left-2 top-1/2 -translate-y-1/2 z-10 w-8 h-8 rounded-full bg-skin-deep/60 backdrop-blur-sm flex items-center justify-center text-skin-dim/80 hover:text-skin-base transition-colors"
+                              className="absolute left-0 top-1/2 -translate-y-1/2 z-10 w-12 h-12 flex items-center justify-center text-skin-base/90 hover:text-skin-base transition-colors"
                               aria-label="Previous character"
                             >
-                              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                                <path d="M10 4L6 8L10 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                              </svg>
+                              <span className="w-9 h-9 rounded-full bg-skin-deep/85 flex items-center justify-center shadow-card">
+                                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+                                  <path d="M10 4L6 8L10 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                </svg>
+                              </span>
                             </button>
                           )}
                           {activeIndex < personas.length - 1 && (
                             <button
                               onClick={() => setActiveIndex((i) => i + 1)}
-                              className="absolute right-2 top-1/2 -translate-y-1/2 z-10 w-8 h-8 rounded-full bg-skin-deep/60 backdrop-blur-sm flex items-center justify-center text-skin-dim/80 hover:text-skin-base transition-colors"
+                              className="absolute right-0 top-1/2 -translate-y-1/2 z-10 w-12 h-12 flex items-center justify-center text-skin-base/90 hover:text-skin-base transition-colors"
                               aria-label="Next character"
                             >
-                              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                                <path d="M6 4L10 8L6 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                              </svg>
+                              <span className="w-9 h-9 rounded-full bg-skin-deep/85 flex items-center justify-center shadow-card">
+                                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+                                  <path d="M6 4L10 8L6 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                </svg>
+                              </span>
                             </button>
                           )}
                         </div>
@@ -459,7 +474,7 @@ export default function InvitePage() {
                               </div>
                               <span
                                 className={`text-[10px] font-display font-bold text-center transition-colors ${
-                                  idx === activeIndex ? 'text-skin-gold' : 'text-skin-dim/40'
+                                  idx === activeIndex ? 'text-skin-gold' : 'text-skin-faint'
                                 }`}
                               >
                                 {persona.name.split(' ')[0]}
@@ -486,10 +501,10 @@ export default function InvitePage() {
                   >
                     <div className="my-auto space-y-4 py-2">
                       <div className="text-center flex-shrink-0">
-                        <div className="text-base font-display font-black text-skin-gold text-glow uppercase tracking-widest">
+                        <h2 className="text-base font-display font-black text-skin-gold text-glow uppercase tracking-widest">
                           Write Your Catfish Bio
-                        </div>
-                        <p className="text-xs text-skin-dim/60 mt-1">This is what other players will see</p>
+                        </h2>
+                        <p className="text-xs text-skin-dim mt-1">First impression. Make it stick.</p>
                       </div>
 
                       {/* Persona identity — prominent, no card (blurred bg IS the card) */}
@@ -502,19 +517,20 @@ export default function InvitePage() {
                         </div>
                       </div>
 
-                      {/* Bio textarea with glass effect */}
+                      {/* Bio textarea — opaque deep panel, gold border for the
+                          one active commit moment (per principle 2: single accent at a time). */}
                       <div className="space-y-2">
                         <textarea
                           value={customBio}
                           onChange={(e) => setCustomBio(e.target.value.slice(0, 280))}
                           placeholder="Write your catfish bio... Who are you pretending to be?"
                           rows={4}
-                          className="w-full px-4 py-3 backdrop-blur-sm rounded-xl text-base font-bold text-skin-gold text-glow placeholder:text-skin-dim placeholder:font-normal focus:outline-none resize-none"
-                          style={{ backgroundColor: 'rgba(44, 0, 62, 0.8)', border: '1px solid var(--po-gold)' }}
+                          aria-label="Catfish bio"
+                          className="w-full px-4 py-3 bg-skin-deep/80 border border-skin-gold rounded-xl text-base font-bold text-skin-gold text-glow placeholder:text-skin-faint placeholder:font-normal focus:outline-none focus:ring-1 focus:ring-skin-gold resize-none"
                         />
-                        <div className="flex justify-between text-xs font-mono">
-                          <span className="text-skin-dim/40">Max 280 characters</span>
-                          <span className={customBio.length > 260 ? 'text-skin-pink' : 'text-skin-dim/40'}>
+                        <div className="flex justify-between text-xs">
+                          <span className="text-skin-faint">Max 280 characters</span>
+                          <span className={customBio.length > 260 ? 'text-skin-pink font-mono tabular-nums' : 'text-skin-faint font-mono tabular-nums'}>
                             {customBio.length}/280
                           </span>
                         </div>
@@ -548,9 +564,13 @@ export default function InvitePage() {
                         setStep(4);
                       }}
                       onSkip={() => {
+                        // Randomize defaults per question. Earlier code defaulted
+                        // every skipped answer to selectedIndex 0, which made
+                        // skippers cluster (every "skip" dossier looked identical
+                        // and told other players "this person didn't engage").
                         const defaultSubs = questions.map(q => ({
                           questionId: q.id,
-                          selectedIndex: 0,
+                          selectedIndex: Math.floor(Math.random() * Math.max(1, q.options.length)),
                         }));
                         const resolved = resolveAnswers(questions, defaultSubs, {
                           name: selectedPersona!.name,
@@ -577,14 +597,23 @@ export default function InvitePage() {
                     className="h-full flex flex-col overflow-y-auto"
                   >
                     <div className="my-auto space-y-3 py-2">
-                      <div className="text-center flex-shrink-0">
-                        <div className="text-base font-display font-black text-skin-gold text-glow uppercase tracking-widest">
-                          Confirm Your Identity
-                        </div>
-                        <p className="text-xs text-skin-dim/60 mt-1">This is who you'll be in the game</p>
+                      <div className="text-center flex-shrink-0 space-y-1">
+                        <p className="text-[10px] font-display font-bold text-skin-faint uppercase tracking-[0.3em]">
+                          You’ll be playing as
+                        </p>
+                        <h2 className="font-display font-black text-skin-base uppercase leading-[0.92] tracking-tight" style={{ fontSize: 'clamp(2.5rem, 11vw, 3.75rem)' }}>
+                          <span className="sr-only">Confirm Your Identity. </span>
+                          {selectedPersona.name}
+                        </h2>
+                        <p className="text-xs font-display font-bold text-skin-gold uppercase tracking-[0.2em]">
+                          {selectedPersona.stereotype}
+                        </p>
                       </div>
 
-                      <div className="bg-skin-panel/30 border border-skin-gold/30 rounded-2xl overflow-hidden">
+                      <div className="relative bg-skin-deep/85 border border-skin-gold/30 rounded-2xl overflow-hidden">
+                        {/* Title-card accent stripe — narrow gold band along the
+                            top of the reveal card. Reads as a cinema slate. */}
+                        <div aria-hidden className="h-[3px] bg-gradient-to-r from-transparent via-skin-gold to-transparent" />
                         <div className="aspect-[16/9] bg-skin-input/30 relative overflow-hidden">
                           <img
                             src={selectedPersona.fullImageUrl}
@@ -599,16 +628,21 @@ export default function InvitePage() {
                             }}
                           />
                           <div className="absolute inset-0 bg-gradient-to-t from-skin-deep/80 to-transparent" />
-                          <div className="absolute bottom-4 left-4 right-4">
-                            <div className="text-lg font-display font-black text-skin-base">{selectedPersona.name}</div>
-                            <div className="text-xs text-skin-gold font-display uppercase tracking-wider">
-                              {selectedPersona.stereotype}
-                            </div>
+
+                          {/* Locked-in stamp — top-right, slightly skewed; reads as
+                              tabloid press-stamp. Reinforces commitment moment without
+                              relying on a banned side-stripe pattern. */}
+                          <div
+                            aria-hidden
+                            className="absolute top-3 right-3 px-2.5 py-1 bg-skin-pink text-skin-base font-display font-black text-[10px] uppercase tracking-[0.18em] rounded-sm"
+                            style={{ transform: 'rotate(3deg)' }}
+                          >
+                            Locked In
                           </div>
                         </div>
                         <div className="p-4 space-y-4">
                           <div>
-                            <div className="text-[10px] font-mono text-skin-dim/50 uppercase tracking-widest mb-2">
+                            <div className="text-[10px] font-display font-bold text-skin-faint uppercase tracking-widest mb-2">
                               Your Bio
                             </div>
                             <p className="text-sm text-skin-base leading-relaxed">{customBio}</p>
@@ -619,13 +653,13 @@ export default function InvitePage() {
                             const answers: { question: string; answer: string }[] = JSON.parse(qaAnswersJson);
                             return answers.length > 0 ? (
                               <div>
-                                <div className="text-[10px] font-mono text-skin-dim/50 uppercase tracking-widest mb-2">
+                                <div className="text-[10px] font-display font-bold text-skin-faint uppercase tracking-widest mb-2">
                                   Your Answers
                                 </div>
                                 <div className="space-y-2">
                                   {answers.map((qa, i) => (
-                                    <div key={i} className="bg-skin-deep/40 rounded-lg px-3 py-2">
-                                      <div className="text-[10px] font-mono text-skin-dim/40 leading-snug">
+                                    <div key={i} className="bg-skin-deep/60 border border-skin-base/40 rounded-lg px-3 py-2">
+                                      <div className="text-[10px] text-skin-dim leading-snug">
                                         {qa.question}
                                       </div>
                                       <div className="text-xs text-skin-gold font-bold leading-snug mt-0.5">
@@ -653,7 +687,7 @@ export default function InvitePage() {
         <div className="flex-shrink-0 relative z-20 bg-gradient-to-b from-skin-deep/0 to-skin-deep pt-3 px-4" style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}>
           <div className="max-w-lg mx-auto">
             {error && (
-              <div className="p-3 mb-3 rounded-lg bg-skin-pink/10 border border-skin-pink/30 text-skin-pink text-sm font-mono text-center">
+              <div role="alert" className="p-3 mb-3 rounded-lg bg-skin-pink/10 border border-skin-pink/30 text-skin-pink text-sm text-center">
                 {error}
               </div>
             )}
@@ -702,7 +736,7 @@ export default function InvitePage() {
                       className={`flex-1 py-4 font-display font-bold text-sm tracking-widest uppercase rounded-xl shadow-lg transition-all
                         ${
                           !selectedPersona
-                            ? 'bg-skin-input text-skin-dim/40 cursor-not-allowed'
+                            ? 'bg-skin-input text-skin-faint cursor-not-allowed'
                             : 'bg-skin-pink text-skin-base shadow-btn hover:brightness-110 active:scale-[0.99]'
                         }`}
                     >
@@ -740,7 +774,7 @@ export default function InvitePage() {
                       className={`flex-1 py-4 font-display font-bold text-sm tracking-widest uppercase rounded-xl shadow-lg transition-all
                         ${
                           !customBio.trim()
-                            ? 'bg-skin-input text-skin-dim/40 cursor-not-allowed'
+                            ? 'bg-skin-input text-skin-faint cursor-not-allowed'
                             : 'bg-skin-gold text-skin-deep shadow-btn hover:brightness-110 active:scale-[0.99]'
                         }`}
                     >
@@ -771,7 +805,7 @@ export default function InvitePage() {
                       className={`flex-1 py-4 font-display font-bold text-sm tracking-widest uppercase rounded-xl shadow-lg transition-all flex items-center justify-center gap-3
                         ${
                           isJoining
-                            ? 'bg-skin-input text-skin-dim/40 cursor-wait'
+                            ? 'bg-skin-input text-skin-faint cursor-wait'
                             : 'bg-skin-pink text-skin-base shadow-btn hover:brightness-110 active:scale-[0.99]'
                         }`}
                     >
@@ -782,7 +816,7 @@ export default function InvitePage() {
                           <span className="w-1.5 h-1.5 bg-current rounded-full animate-bounce delay-150"></span>
                         </>
                       ) : (
-                        <>Join Game</>
+                        <>Take the seat</>
                       )}
                     </button>
                   </div>

--- a/apps/lobby/app/layout.tsx
+++ b/apps/lobby/app/layout.tsx
@@ -11,7 +11,7 @@ export const viewport: Viewport = {
 
 const SITE_TITLE = "Pecking Order";
 const SITE_DESCRIPTION =
-  "A social game of alliances, betrayal, and strategy. Your friends are your rivals.";
+  "Vote. Ally. Betray. Survive. A social deduction game in your group chat. Seven days. One winner.";
 
 // `generateMetadata` (instead of the static `metadata` export) so we can read
 // LOBBY_HOST from the Cloudflare env and emit absolute og:image / og:url.

--- a/apps/lobby/app/login/page.tsx
+++ b/apps/lobby/app/login/page.tsx
@@ -13,13 +13,24 @@ function LoginForm() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
+  function isLikelyEmail(value: string): boolean {
+    // Loose validation — server-side enforces the real rules. This is just
+    // enough to keep "tap the button to find out what's wrong" honest.
+    return /^\S+@\S+\.\S+$/.test(value.trim());
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setMagicLink(null);
     setEmailSent(false);
-    setIsLoading(true);
 
+    if (!isLikelyEmail(email)) {
+      setError('That email looks off. Double-check and try again.');
+      return;
+    }
+
+    setIsLoading(true);
     const result = await requestMagicLink(email, next);
     setIsLoading(false);
 
@@ -40,121 +51,121 @@ function LoginForm() {
   }
 
   return (
-    <div className="bg-skin-panel/30 backdrop-blur-md border border-skin-base p-1 rounded-3xl shadow-card overflow-hidden">
-      <div className="bg-skin-deep/60 rounded-[20px] p-8 border border-skin-base space-y-6">
+    <div className="bg-skin-deep/70 border border-skin-base rounded-3xl p-7 sm:p-8 shadow-card space-y-6">
 
-        {!magicLink && !emailSent ? (
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="space-y-3">
-              <label htmlFor="email" className="text-xs font-bold text-skin-dim uppercase tracking-widest pl-1 font-display">
-                Email Address
-              </label>
-              <input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="player@example.com"
-                required
-                className="w-full bg-skin-input text-skin-base border border-skin-base rounded-xl px-5 py-4 focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 transition-all font-mono text-sm placeholder:text-skin-dim/30"
-              />
+      {!magicLink && !emailSent ? (
+        <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+          <div className="space-y-3">
+            <label htmlFor="email" className="block text-xs font-bold text-skin-dim uppercase tracking-widest pl-1 font-display">
+              Email Address
+            </label>
+            <input
+              id="email"
+              type="email"
+              inputMode="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="player@example.com"
+              className="w-full bg-skin-input text-skin-base border border-skin-base rounded-xl px-5 py-4 focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 transition-all text-base placeholder:text-skin-faint"
+            />
+          </div>
+
+          {error && (
+            <div role="alert" className="p-3 rounded-lg bg-skin-pink/10 border border-skin-pink/30 text-skin-pink text-sm">
+              {error}
             </div>
+          )}
 
-            {error && (
-              <div className="p-3 rounded-lg bg-skin-pink/10 border border-skin-pink/30 text-skin-pink text-sm font-mono">
-                {error}
-              </div>
+          <button
+            type="submit"
+            disabled={isLoading}
+            aria-busy={isLoading}
+            className={`group w-full py-5 font-display font-bold text-sm tracking-widest uppercase rounded-xl transition-all flex items-center justify-center gap-3 relative overflow-hidden
+              ${isLoading
+                ? 'bg-skin-input text-skin-faint cursor-wait'
+                : 'bg-skin-pink text-skin-base shadow-btn btn-press hover:brightness-110 active:scale-[0.99]'
+              }`}
+          >
+            {isLoading ? (
+              <>
+                <span className="w-1.5 h-1.5 bg-current rounded-full animate-bounce"></span>
+                <span className="w-1.5 h-1.5 bg-current rounded-full animate-bounce delay-75"></span>
+                <span className="w-1.5 h-1.5 bg-current rounded-full animate-bounce delay-150"></span>
+              </>
+            ) : (
+              <>Send Magic Link</>
             )}
-
-            <button
-              type="submit"
-              disabled={isLoading || !email}
-              className={`group w-full py-5 font-display font-bold text-sm tracking-widest uppercase rounded-xl shadow-lg transform transition-all flex items-center justify-center gap-3 relative overflow-hidden
-                ${isLoading
-                  ? 'bg-skin-input text-skin-dim/40 cursor-wait'
-                  : 'bg-skin-pink text-skin-base shadow-btn btn-press hover:brightness-110 active:scale-[0.99]'
-                }`}
-            >
-              {isLoading ? (
-                <>
-                  <span className="w-1.5 h-1.5 bg-current rounded-full animate-bounce"></span>
-                  <span className="w-1.5 h-1.5 bg-current rounded-full animate-bounce delay-75"></span>
-                  <span className="w-1.5 h-1.5 bg-current rounded-full animate-bounce delay-150"></span>
-                </>
-              ) : (
-                <>Send Magic Link</>
-              )}
-            </button>
-          </form>
-        ) : emailSent ? (
-          <div className="space-y-4">
-            <div className="text-center space-y-2">
-              <div className="text-skin-green font-display font-bold text-sm uppercase tracking-widest">
-                Check Your Email
-              </div>
-              <p className="text-skin-dim text-sm">
-                We sent a login link to <span className="text-skin-base font-bold">{email}</span>
-              </p>
-              <p className="text-skin-dim/60 text-xs">
-                Check your inbox (and spam folder). The link expires in 5 minutes.
-              </p>
-            </div>
-
-            <button
-              onClick={handleSubmit}
-              disabled={isLoading}
-              className="block w-full py-3 text-center text-skin-dim text-xs font-mono hover:text-skin-base transition-colors disabled:opacity-40"
-            >
-              {isLoading ? 'Sending...' : "Didn't receive it? Resend"}
-            </button>
-
-            <button
-              onClick={handleReset}
-              className="w-full py-3 text-center text-skin-dim text-xs font-mono hover:text-skin-base transition-colors"
-            >
-              Try different email
-            </button>
+          </button>
+        </form>
+      ) : emailSent ? (
+        <div className="space-y-4">
+          <div className="text-center space-y-2">
+            <h2 className="text-skin-green font-display font-bold text-sm uppercase tracking-widest">
+              Check Your Email
+            </h2>
+            <p className="text-skin-dim text-sm">
+              We sent a login link to <span className="text-skin-base font-bold">{email}</span>
+            </p>
+            <p className="text-skin-faint text-xs">
+              Check your inbox (and spam folder). The link expires in 5 minutes.
+            </p>
           </div>
-        ) : (
-          <div className="space-y-4">
-            <div className="text-center space-y-2">
-              <div className="text-skin-green font-display font-bold text-sm uppercase tracking-widest">
-                Link Generated
-              </div>
-              <p className="text-skin-dim text-sm">
-                In production this would be emailed. For now, click below:
-              </p>
-            </div>
 
-            <a
-              href={magicLink!}
-              className="block w-full py-4 text-center bg-skin-green/10 text-skin-green border border-skin-green/30 rounded-xl font-mono text-sm hover:bg-skin-green/20 transition-all"
-            >
-              Click to Sign In
-            </a>
+          <button
+            onClick={handleSubmit}
+            disabled={isLoading}
+            className="block w-full py-3 text-center text-skin-dim text-xs hover:text-skin-base transition-colors disabled:opacity-40 underline-offset-4 hover:underline"
+          >
+            {isLoading ? 'Sending…' : "Didn't receive it? Resend"}
+          </button>
 
-            <button
-              onClick={handleReset}
-              className="w-full py-3 text-center text-skin-dim text-xs font-mono hover:text-skin-base transition-colors"
-            >
-              Try different email
-            </button>
+          <button
+            onClick={handleReset}
+            className="w-full py-3 text-center text-skin-dim text-xs hover:text-skin-base transition-colors underline-offset-4 hover:underline"
+          >
+            Try different email
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="text-center space-y-2">
+            <h2 className="text-skin-green font-display font-bold text-sm uppercase tracking-widest">
+              Link Generated
+            </h2>
+            <p className="text-skin-dim text-sm">
+              In production this would be emailed. For now, click below:
+            </p>
           </div>
-        )}
 
-      </div>
+          <a
+            href={magicLink!}
+            className="block w-full py-4 text-center bg-skin-green/10 text-skin-green border border-skin-green/30 rounded-xl font-display font-bold uppercase tracking-widest text-sm hover:bg-skin-green/20 transition-all"
+          >
+            Click to Sign In
+          </a>
+
+          <button
+            onClick={handleReset}
+            className="w-full py-3 text-center text-skin-dim text-xs hover:text-skin-base transition-colors underline-offset-4 hover:underline"
+          >
+            Try different email
+          </button>
+        </div>
+      )}
+
     </div>
   );
 }
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen bg-skin-deep bg-grid-pattern flex flex-col items-center justify-center p-4 font-body text-skin-base relative selection:bg-skin-gold/30">
+    <div className="min-h-dvh bg-skin-deep bg-grid-pattern flex flex-col items-center justify-center p-4 pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))] font-body text-skin-base relative selection:bg-skin-gold/30">
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-gradient-radial from-skin-panel/40 to-transparent opacity-60 pointer-events-none" />
 
       <div className="max-w-md w-full relative z-10">
-        <header className="text-center mb-12 space-y-4">
-          <h1 className="text-5xl md:text-6xl font-display font-black tracking-tighter text-skin-gold mb-2 text-glow">
+        <header className="text-center mb-10 sm:mb-12 space-y-4">
+          <h1 className="font-display font-black tracking-tighter text-skin-gold text-glow leading-[0.9]" style={{ fontSize: 'clamp(2.5rem, 11vw, 4rem)' }}>
             PECKING ORDER
           </h1>
           <p className="text-lg text-skin-dim font-light tracking-wide">
@@ -163,10 +174,8 @@ export default function LoginPage() {
         </header>
 
         <Suspense fallback={
-          <div className="bg-skin-panel/30 backdrop-blur-md border border-skin-base p-1 rounded-3xl shadow-card overflow-hidden">
-            <div className="bg-skin-deep/60 rounded-[20px] p-8 border border-skin-base flex items-center justify-center">
-              <span className="text-skin-dim/40 font-mono text-sm">Loading...</span>
-            </div>
+          <div className="bg-skin-deep/70 border border-skin-base rounded-3xl p-8 flex items-center justify-center shadow-card">
+            <span className="text-skin-faint text-sm">Pulling your session…</span>
           </div>
         }>
           <LoginForm />

--- a/apps/lobby/app/playtest/layout.tsx
+++ b/apps/lobby/app/playtest/layout.tsx
@@ -3,7 +3,7 @@ import { getEnv } from '@/lib/db';
 
 const FALLBACK_TITLE = 'Pecking Order — Join the Playtest';
 const FALLBACK_DESCRIPTION =
-  'A social game of alliances, betrayal & strategy. Sign up to play.';
+  'Vote. Ally. Betray. Survive. A social deduction game in your group chat. Reserve your seat in the next playtest.';
 
 // Distinct magenta for the signup funnel — visually separates the playtest
 // onboarding from the in-game `#0f0a1a` palette. Root lobby layout sets

--- a/apps/lobby/app/playtest/page.tsx
+++ b/apps/lobby/app/playtest/page.tsx
@@ -1,5 +1,4 @@
 import { getDB, getEnv } from '@/lib/db';
-import { Vote, Handshake, Sword, Crown } from 'lucide-react';
 import { PersonaCarousel } from './persona-carousel';
 import { SignupForm } from './signup-form';
 import { ShareButtons } from './share-buttons';
@@ -26,19 +25,6 @@ async function getRandomPersonas(count: number): Promise<Persona[]> {
   }
 }
 
-function TeaserBadge({ Icon, label }: { Icon: typeof Vote; label: string }) {
-  return (
-    <div className="flex flex-col items-center gap-2">
-      <div className="w-14 h-14 rounded-full bg-skin-gold/10 flex items-center justify-center">
-        <Icon size={24} className="text-skin-gold" strokeWidth={1.5} />
-      </div>
-      <span className="text-skin-dim text-[11px] font-bold uppercase tracking-wider">
-        {label}
-      </span>
-    </div>
-  );
-}
-
 export default async function PlaytestPage() {
   const [personas, env] = await Promise.all([
     getRandomPersonas(10),
@@ -56,14 +42,14 @@ export default async function PlaytestPage() {
       <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[900px] h-[700px] bg-gradient-radial from-skin-panel/60 via-skin-panel/20 to-transparent opacity-80 pointer-events-none" />
 
       {/* Hero */}
-      <header className="relative pt-8 pb-2 px-4 text-center">
-        <h1 className="font-display font-black text-4xl md:text-6xl text-skin-gold tracking-tight text-glow mb-2">
+      <header className="relative pt-[max(2rem,env(safe-area-inset-top))] pb-2 px-4 text-center">
+        <h1 className="font-display font-black text-skin-gold tracking-tight text-glow mb-2 leading-[0.9]" style={{ fontSize: 'clamp(2.75rem, 12vw, 4.5rem)' }}>
           PECKING ORDER
         </h1>
-        <p className="text-skin-dim text-base md:text-lg font-display font-light tracking-wide mb-4 max-w-sm mx-auto">
+        <p className="text-skin-dim text-base md:text-lg font-light tracking-wide mb-4 max-w-sm mx-auto">
           A social game of alliances, betrayal & strategy
         </p>
-        <span className="inline-block bg-skin-gold/10 rounded-full px-5 py-2 text-skin-gold text-xs font-bold uppercase tracking-[0.2em] animate-pulse-live mb-8">
+        <span className="inline-block bg-skin-gold/10 rounded-full px-5 py-2 text-skin-gold text-xs font-bold uppercase tracking-[0.2em] mb-8">
           Playtesting Now
         </span>
 
@@ -77,12 +63,12 @@ export default async function PlaytestPage() {
 
       {/* Form */}
       <main className="relative px-5 py-10 max-w-md mx-auto">
-        <div className="bg-skin-panel/30 backdrop-blur-sm rounded-3xl p-7 md:p-8 shadow-[0_8px_40px_rgba(0,0,0,0.3)]">
+        <div className="bg-skin-deep/70 border border-skin-base rounded-3xl p-7 md:p-8 shadow-card">
           <div className="text-center mb-7">
-            <h2 className="font-display font-bold text-xl text-skin-base mb-1.5">
+            <h2 className="font-display font-black text-2xl text-skin-base mb-1.5 uppercase tracking-tight">
               Join the Next Playtest
             </h2>
-            <p className="text-skin-dim text-sm font-display">
+            <p className="text-skin-dim text-sm">
               Be the first to know when we're ready for you.
             </p>
           </div>
@@ -90,15 +76,15 @@ export default async function PlaytestPage() {
         </div>
       </main>
 
-      {/* Teaser Strip */}
-      <section className="relative py-10 px-6">
-        <div className="flex gap-6 md:gap-10 justify-center mb-4">
-          <TeaserBadge Icon={Vote} label="Vote" />
-          <TeaserBadge Icon={Handshake} label="Ally" />
-          <TeaserBadge Icon={Sword} label="Betray" />
-          <TeaserBadge Icon={Crown} label="Survive" />
+      {/* What you'll do — typographic statement, not iconified card row */}
+      <section className="relative py-12 px-6 max-w-md mx-auto text-center">
+        <div className="font-display font-black uppercase leading-[0.95] tracking-tight text-skin-base" style={{ fontSize: 'clamp(2rem, 9vw, 3.25rem)' }}>
+          <div>Vote.</div>
+          <div className="text-skin-gold">Ally.</div>
+          <div>Betray.</div>
+          <div className="text-skin-pink">Survive.</div>
         </div>
-        <p className="text-center text-skin-dim/40 text-xs tracking-wide font-display">
+        <p className="text-skin-faint text-xs tracking-wide mt-6">
           Play from your phone. Games run over multiple days.
         </p>
       </section>
@@ -109,10 +95,10 @@ export default async function PlaytestPage() {
       </section>
 
       {/* Footer */}
-      <footer className="relative py-6 text-center">
+      <footer className="relative py-6 text-center pb-[max(1.5rem,env(safe-area-inset-bottom))]">
         <a
           href="https://peckingorder.ca"
-          className="text-skin-dim/30 text-xs hover:text-skin-dim transition-colors font-mono tracking-wider"
+          className="text-skin-faint text-xs hover:text-skin-dim transition-colors tracking-wider"
         >
           peckingorder.ca
         </a>

--- a/apps/lobby/app/playtest/persona-carousel.tsx
+++ b/apps/lobby/app/playtest/persona-carousel.tsx
@@ -28,8 +28,8 @@ function PersonaCard({
     <div
       className={`relative overflow-hidden flex-shrink-0 ${
         featured
-          ? 'w-40 h-56 md:w-48 md:h-64 rounded-2xl shadow-[0_0_40px_rgba(251,191,36,0.2)] z-10'
-          : 'w-28 h-40 md:w-32 md:h-44 rounded-2xl shadow-[0_12px_40px_rgba(0,0,0,0.6)]'
+          ? 'w-40 h-56 md:w-48 md:h-64 rounded-2xl shadow-glow z-10'
+          : 'w-28 h-40 md:w-32 md:h-44 rounded-2xl shadow-card'
       }`}
     >
       <img

--- a/apps/lobby/app/playtest/share-buttons.tsx
+++ b/apps/lobby/app/playtest/share-buttons.tsx
@@ -2,8 +2,51 @@
 
 import { useState } from 'react';
 
-const SHARE_TEXT =
-  'Check out Pecking Order — a social game of alliances, betrayal & strategy. Sign up for the next playtest!';
+// Brand mantra echoed across every channel — recipients should see the same
+// four-word hook regardless of where the link lands. Per-channel variants
+// adapt format (Twitter trims hard, WhatsApp likes line-breaks, Discord uses
+// markdown bolds) but the verbs stay consistent.
+const MANTRA = 'Vote. Ally. Betray. Survive.';
+const TAGLINE = 'A social deduction game in your group chat.';
+const SHARE_TEXT = `${MANTRA} ${TAGLINE} Reserve your seat for the next Pecking Order playtest.`;
+
+// Robust clipboard write — `navigator.clipboard` is unavailable in
+// non-secure contexts (some embedded browsers, older iOS in-app webviews)
+// and can reject silently when the document isn't focused. The textarea
+// fallback covers most of those cases.
+async function writeClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'absolute';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+// Popup blockers can return null from window.open; fall back to navigation
+// in the same tab so the share intent still completes.
+function openShareIntent(url: string) {
+  const win = window.open(url, '_blank', 'noopener,noreferrer');
+  if (!win) {
+    window.location.href = url;
+  }
+}
 
 function TwitterIcon() {
   return (
@@ -46,6 +89,14 @@ function EmailIcon() {
   );
 }
 
+function SmsIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+    </svg>
+  );
+}
+
 function LinkIcon() {
   return (
     <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -60,39 +111,59 @@ export function ShareButtons({ emphasis = false, referralCode, playtestUrl }: { 
 
   const shareUrl = referralCode ? `${playtestUrl}?ref=${referralCode}` : playtestUrl;
 
+  // Twitter has the tightest budget (display ~280 chars including URL).
+  // Lead with the mantra; let the URL preview carry the rest.
   function shareTwitter() {
-    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(SHARE_TEXT)}&url=${encodeURIComponent(shareUrl)}`;
-    window.open(url, '_blank', 'noopener,noreferrer');
+    const tweet = `${MANTRA} The group-chat reality show is forming. Reserve a seat:`;
+    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweet)}&url=${encodeURIComponent(shareUrl)}`;
+    openShareIntent(url);
   }
 
+  // WhatsApp renders newlines as visual line breaks in the chat preview, so
+  // we stack the mantra over the tagline over the URL — reads like a poster.
   function shareWhatsApp() {
-    const url = `https://wa.me/?text=${encodeURIComponent(`${SHARE_TEXT}\n${shareUrl}`)}`;
-    window.open(url, '_blank', 'noopener,noreferrer');
+    const text = `${MANTRA}\n${TAGLINE}\n\nReserve a seat:\n${shareUrl}`;
+    const url = `https://wa.me/?text=${encodeURIComponent(text)}`;
+    openShareIntent(url);
   }
 
   function shareReddit() {
-    const url = `https://reddit.com/submit?url=${encodeURIComponent(shareUrl)}&title=${encodeURIComponent('Pecking Order — A social game of alliances, betrayal & strategy')}`;
-    window.open(url, '_blank', 'noopener,noreferrer');
+    const url = `https://reddit.com/submit?url=${encodeURIComponent(shareUrl)}&title=${encodeURIComponent(`Pecking Order — ${MANTRA} A social deduction game in your group chat`)}`;
+    openShareIntent(url);
   }
 
-  function shareDiscord() {
-    navigator.clipboard.writeText(
-      `**Pecking Order** — A social game of alliances, betrayal & strategy\nSign up for the next playtest:\n${shareUrl}`,
-    );
-    setCopiedBtn('discord');
-    setTimeout(() => setCopiedBtn(null), 2000);
+  // Discord supports markdown — bold the title, surface the mantra as its
+  // own line for visual punch in the channel.
+  async function shareDiscord() {
+    const text = `**Pecking Order**\n${MANTRA}\n${TAGLINE}\nReserve a seat: ${shareUrl}`;
+    const ok = await writeClipboard(text);
+    if (ok) {
+      setCopiedBtn('discord');
+      setTimeout(() => setCopiedBtn(null), 2000);
+    }
+  }
+
+  // SMS share — sms: link works on iOS, Android, and macOS Messages.app.
+  // Mantra-led, short enough to land cleanly in a single SMS bubble.
+  function shareSms() {
+    const text = `${MANTRA} ${shareUrl}`;
+    // iOS uses ?&body=, Android uses ?body= — the &-prefix form works on both.
+    const url = `sms:?&body=${encodeURIComponent(text)}`;
+    window.location.href = url;
   }
 
   function shareEmail() {
-    const subject = encodeURIComponent('Check out Pecking Order');
-    const body = encodeURIComponent(`${SHARE_TEXT}\n\n${shareUrl}`);
+    const subject = encodeURIComponent(`${MANTRA} (Pecking Order playtest)`);
+    const body = encodeURIComponent(`${MANTRA}\n${TAGLINE}\n\nReserve a seat in the next Pecking Order playtest:\n${shareUrl}`);
     window.location.href = `mailto:?subject=${subject}&body=${body}`;
   }
 
-  function copyLink() {
-    navigator.clipboard.writeText(shareUrl);
-    setCopiedBtn('link');
-    setTimeout(() => setCopiedBtn(null), 2000);
+  async function copyLink() {
+    const ok = await writeClipboard(shareUrl);
+    if (ok) {
+      setCopiedBtn('link');
+      setTimeout(() => setCopiedBtn(null), 2000);
+    }
   }
 
   const circleSize = emphasis ? 'w-12 h-12' : 'w-11 h-11';
@@ -101,16 +172,16 @@ export function ShareButtons({ emphasis = false, referralCode, playtestUrl }: { 
     <div className="text-center">
       {emphasis ? (
         <>
-          <p className="text-skin-gold font-display font-bold text-lg mb-1">
-            Spread the word!
+          <p className="text-skin-gold font-display font-black uppercase tracking-tight text-2xl mb-1">
+            Bring your people
           </p>
-          <p className="text-skin-dim text-sm font-display mb-5">
-            Pecking Order is better with friends...or enemies.
+          <p className="text-skin-dim text-sm mb-5">
+            Pecking Order is better with friends. Or enemies.
           </p>
         </>
       ) : (
-        <p className="text-skin-dim text-sm font-display mb-4">
-          Pecking Order is better with friends...or enemies.
+        <p className="text-skin-dim text-sm mb-4">
+          Pecking Order is better with friends. Or enemies.
         </p>
       )}
       <div className="flex gap-3 justify-center items-center">
@@ -145,6 +216,13 @@ export function ShareButtons({ emphasis = false, referralCode, playtestUrl }: { 
           className={`${circleSize} rounded-full bg-[#FF4500] text-white hover:brightness-110 transition-all flex items-center justify-center hover:scale-110`}
         >
           <RedditIcon />
+        </button>
+        <button
+          onClick={shareSms}
+          aria-label="Share via SMS"
+          className={`${circleSize} rounded-full bg-[#22c55e] text-white hover:brightness-110 transition-all flex items-center justify-center hover:scale-110`}
+        >
+          <SmsIcon />
         </button>
         <button
           onClick={shareEmail}

--- a/apps/lobby/app/playtest/share/[code]/client.tsx
+++ b/apps/lobby/app/playtest/share/[code]/client.tsx
@@ -18,24 +18,33 @@ export function SharePageClient({ code, playtestUrl }: { code: string; playtestU
   }, [referralCode]);
 
   return (
-    <div className="min-h-screen bg-skin-deep bg-grid-pattern font-body text-skin-base selection:bg-skin-gold/30 relative overflow-hidden flex items-center justify-center">
+    <div className="min-h-dvh bg-skin-deep bg-grid-pattern font-body text-skin-base selection:bg-skin-gold/30 relative overflow-hidden flex items-center justify-center pt-[max(1rem,env(safe-area-inset-top))] pb-[max(1rem,env(safe-area-inset-bottom))]">
       {/* Ambient glow */}
       <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[900px] h-[700px] bg-gradient-radial from-skin-panel/60 via-skin-panel/20 to-transparent opacity-80 pointer-events-none" />
 
       <main className="relative px-5 py-10 max-w-md mx-auto w-full">
-        <div className="bg-skin-panel/30 backdrop-blur-sm rounded-3xl p-7 md:p-8 shadow-[0_8px_40px_rgba(0,0,0,0.3)]">
+        <div className="bg-skin-deep/70 border border-skin-base rounded-3xl p-7 md:p-8 shadow-card">
           <div className="text-center space-y-3 mb-6">
             <h1 className="font-display font-black text-2xl md:text-3xl text-skin-gold tracking-tight text-glow">
               PECKING ORDER
             </h1>
-            <p className="text-skin-dim text-sm font-display">
+            <p className="text-skin-dim text-sm">
               Share your link to recruit players for the next playtest.
             </p>
           </div>
 
-          {/* Referral code display */}
+          {/* Brand verb-stack — same mantra as /playtest hero, gives the share
+              surface its own typographic anchor instead of just listing chrome. */}
+          <div className="text-center mb-6 font-display font-black uppercase leading-[0.95] tracking-tight" style={{ fontSize: 'clamp(1.75rem, 8vw, 2.5rem)' }}>
+            <div className="text-skin-base">Vote.</div>
+            <div className="text-skin-gold">Ally.</div>
+            <div className="text-skin-base">Betray.</div>
+            <div className="text-skin-pink">Survive.</div>
+          </div>
+
+          {/* Referral code display — mono is the right call here, this IS a code */}
           <div className="text-center py-3 mb-6 bg-skin-deep/40 rounded-xl border border-skin-gold/15">
-            <p className="text-[10px] font-bold text-skin-dim uppercase tracking-[0.2em] mb-1.5 font-display">
+            <p className="text-[10px] font-display font-bold text-skin-dim uppercase tracking-[0.2em] mb-1.5">
               Your Referral Code
             </p>
             <p className="text-2xl font-mono font-bold text-skin-gold tracking-[0.3em]">
@@ -49,7 +58,7 @@ export function SharePageClient({ code, playtestUrl }: { code: string; playtestU
         <footer className="mt-8 text-center">
           <a
             href="https://peckingorder.ca"
-            className="text-skin-dim/30 text-xs hover:text-skin-dim transition-colors font-mono tracking-wider"
+            className="text-skin-faint text-xs hover:text-skin-dim transition-colors tracking-wider"
           >
             peckingorder.ca
           </a>

--- a/apps/lobby/app/playtest/share/[code]/page.tsx
+++ b/apps/lobby/app/playtest/share/[code]/page.tsx
@@ -1,5 +1,46 @@
+import type { Metadata } from 'next';
 import { getEnv } from '@/lib/db';
 import { SharePageClient } from './client';
+
+// Referral-link unfurl. The recruit just signed up and is sharing this URL
+// to bring more people in — every share should sell the show, not look
+// like generic site chrome.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ code: string }>;
+}): Promise<Metadata> {
+  const { code } = await params;
+  const env = await getEnv();
+  const lobbyHost = (env.LOBBY_HOST as string) || 'https://lobby.peckingorder.ca';
+  const playtestUrl = (env.PLAYTEST_URL as string) || `${lobbyHost}/playtest`;
+  const ogImage = `${lobbyHost}/og-playtest.png`;
+  const url = `${playtestUrl}/share/${code.toUpperCase()}`;
+
+  const title = "You're on the list — bring your people";
+  const description = 'Vote. Ally. Betray. Survive. The next Pecking Order playtest is forming. Reserve your seat.';
+
+  return {
+    metadataBase: new URL(lobbyHost),
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: 'Pecking Order',
+      images: [{ url: ogImage, width: 1200, height: 630, alt: 'Pecking Order — Vote. Ally. Betray. Survive.' }],
+      type: 'website',
+      locale: 'en_US',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
+  };
+}
 
 export default async function SharePage({
   params,

--- a/apps/lobby/app/playtest/signup-form.tsx
+++ b/apps/lobby/app/playtest/signup-form.tsx
@@ -121,7 +121,7 @@ export function SignupForm({ turnstileSiteKey, playtestUrl }: { turnstileSiteKey
           onChange={(e) => setEmail(e.target.value)}
           placeholder="you@example.com"
           required
-          className="w-full bg-skin-input text-skin-base border border-skin-base rounded-xl px-4 py-3.5 focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 transition-all text-sm placeholder:text-skin-dim/30"
+          className="w-full bg-skin-input text-skin-base border border-skin-base rounded-xl px-4 py-3.5 focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 transition-all text-sm placeholder:text-skin-faint"
         />
       </div>
 
@@ -131,7 +131,7 @@ export function SignupForm({ turnstileSiteKey, playtestUrl }: { turnstileSiteKey
           className="text-xs font-bold text-skin-dim uppercase tracking-widest pl-1 font-display"
         >
           Phone
-          <span className="normal-case tracking-normal font-normal text-skin-dim/50 ml-1">optional</span>
+          <span className="normal-case tracking-normal font-normal text-skin-faint ml-1">optional</span>
         </label>
         <input
           id="signup-phone"
@@ -140,7 +140,7 @@ export function SignupForm({ turnstileSiteKey, playtestUrl }: { turnstileSiteKey
           onChange={(e) => setPhone(e.target.value)}
           placeholder="+1 (555) 123-4567"
           maxLength={20}
-          className="w-full bg-skin-input text-skin-base border border-skin-base rounded-xl px-4 py-3.5 focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 transition-all text-sm placeholder:text-skin-dim/30"
+          className="w-full bg-skin-input text-skin-base border border-skin-base rounded-xl px-4 py-3.5 focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 transition-all text-sm placeholder:text-skin-faint"
         />
       </div>
 
@@ -150,7 +150,7 @@ export function SignupForm({ turnstileSiteKey, playtestUrl }: { turnstileSiteKey
           className="text-xs font-bold text-skin-dim uppercase tracking-widest pl-1 font-display"
         >
           Preferred Messaging App
-          <span className="normal-case tracking-normal font-normal text-skin-dim/50 ml-1">optional</span>
+          <span className="normal-case tracking-normal font-normal text-skin-faint ml-1">optional</span>
         </label>
         <select
           id="signup-messaging"
@@ -199,7 +199,7 @@ export function SignupForm({ turnstileSiteKey, playtestUrl }: { turnstileSiteKey
             className="text-xs font-bold text-skin-dim uppercase tracking-widest pl-1 font-display"
           >
             Who referred you?
-            <span className="normal-case tracking-normal font-normal text-skin-dim/50 ml-1">optional</span>
+            <span className="normal-case tracking-normal font-normal text-skin-faint ml-1">optional</span>
           </label>
           <input
             id="signup-referral-detail"
@@ -208,7 +208,7 @@ export function SignupForm({ turnstileSiteKey, playtestUrl }: { turnstileSiteKey
             onChange={(e) => setReferralDetail(e.target.value)}
             placeholder="Their name or email"
             maxLength={200}
-            className="w-full bg-skin-input text-skin-base border border-skin-base rounded-xl px-4 py-3.5 focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 transition-all text-sm placeholder:text-skin-dim/30"
+            className="w-full bg-skin-input text-skin-base border border-skin-base rounded-xl px-4 py-3.5 focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 transition-all text-sm placeholder:text-skin-faint"
           />
         </div>
       )}
@@ -228,7 +228,7 @@ export function SignupForm({ turnstileSiteKey, playtestUrl }: { turnstileSiteKey
             onChange={(e) => setReferralDetail(e.target.value)}
             placeholder="Where did you find us?"
             maxLength={200}
-            className="w-full bg-skin-input text-skin-base border border-skin-base rounded-xl px-4 py-3.5 focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 transition-all text-sm placeholder:text-skin-dim/30"
+            className="w-full bg-skin-input text-skin-base border border-skin-base rounded-xl px-4 py-3.5 focus:outline-none focus:ring-1 focus:ring-skin-gold/50 focus:border-skin-gold/50 transition-all text-sm placeholder:text-skin-faint"
           />
         </div>
       )}
@@ -256,7 +256,7 @@ export function SignupForm({ turnstileSiteKey, playtestUrl }: { turnstileSiteKey
         className={`w-full py-4 font-display font-bold text-sm tracking-widest uppercase rounded-xl transition-all flex items-center justify-center gap-3
           ${
             isLoading
-              ? 'bg-skin-input text-skin-dim/40 cursor-wait'
+              ? 'bg-skin-input text-skin-faint cursor-wait'
               : 'bg-skin-gold text-skin-deep shadow-btn btn-press hover:brightness-110 active:scale-[0.99]'
           }`}
       >

--- a/apps/lobby/lib/email-templates.ts
+++ b/apps/lobby/lib/email-templates.ts
@@ -124,6 +124,24 @@ function bodyLine(text: string): string {
   return `<p style="margin:0 0 28px;font-family:${BODY};font-size:16px;line-height:1.55;color:${TEXT};">${text}</p>`;
 }
 
+/** Stacked-verb statement. Each word becomes its own line in giant display
+ * type with alternating accents. Used as a typographic moment that names the
+ * game shape with no chrome. Mirrors the `/playtest` web treatment.
+ *
+ * Default colors rotate TEXT → GOLD → TEXT → CTA. Pass a `colors` array to
+ * override per-line. Line-height is set to 1.0 for Outlook safety; we add an
+ * explicit margin between lines so the stack still has air on tight rendererss. */
+function verbStack(words: string[], colors?: string[]): string {
+  const palette = colors ?? [TEXT, GOLD, TEXT, CTA];
+  return `<div style="margin:0 0 32px;text-align:center;">${words
+    .map((word, i) => {
+      const color = palette[i % palette.length];
+      const isLast = i === words.length - 1;
+      return `<div style="font-family:${DISPLAY};font-size:52px;font-weight:900;line-height:1.0;letter-spacing:-0.02em;color:${color};text-transform:uppercase;${isLast ? '' : 'margin-bottom:6px;'}">${word}</div>`;
+    })
+    .join('')}</div>`;
+}
+
 /** Code block — tracked display glyphs over tiny label */
 function codeBlock(label: string, code: string): string {
   return `<div style="text-align:left;">
@@ -176,7 +194,8 @@ export function buildInviteEmail(opts: {
     ${card(`
       ${eyebrow('Cast list')}
       ${hugeLine(`${sender} added you`)}
-      ${bodyLine('Pecking Order is a social deduction game you play in a group chat. Pick a character, form alliances, and try not to get voted out. A few minutes a day on your phone. Last one standing wins.')}
+      ${bodyLine('Pecking Order is a social deduction game you play in a group chat. A few minutes a day on your phone. Last one standing wins.')}
+      ${verbStack(['Vote.', 'Ally.', 'Betray.', 'Survive.'])}
       ${buttonRow('Take your spot', opts.inviteLink, 28)}
       ${hairline()}
       ${codeBlock('Invite code', opts.inviteCode)}
@@ -232,7 +251,9 @@ export function buildPlaytestConfirmationEmail(opts: {
     ${card(`
       ${eyebrow('Confirmed')}
       ${hugeLine('You&rsquo;re in', GOLD)}
-      ${bodyLine('Next playtest drops soon. Here&rsquo;s the shape of it:')}
+      ${bodyLine('Next playtest drops soon. The shape of it:')}
+
+      ${verbStack(['Vote.', 'Ally.', 'Betray.', 'Survive.'])}
 
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 28px;">
         ${beat('01', 'Pick a face', 'Play a persona with their own history, drama, and enemies.')}

--- a/apps/lobby/middleware.ts
+++ b/apps/lobby/middleware.ts
@@ -1,5 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+// Routes the matcher fires on but that should NOT require a session.
+// `/playtest` is the public recruitment / signup hub; `/playtest/share/:code`
+// is the public referral landing; `/share/:code` is the vanity-domain
+// shortcut that rewrites into `/playtest/share/:code`. All three need to be
+// reachable by unauthenticated visitors landing from SMS / DM / social.
+function isPublicPath(pathname: string): boolean {
+  return pathname === '/playtest' ||
+    pathname.startsWith('/playtest/share/') ||
+    pathname.startsWith('/share/');
+}
+
 export function middleware(req: NextRequest) {
   // Vanity domain: playtest.peckingorder.ca → serve /playtest/* pages (rewrite, not redirect)
   const host = req.headers.get('host') || '';
@@ -13,6 +24,13 @@ export function middleware(req: NextRequest) {
     }
   }
 
+  // Public routes: skip the session gate. Avoids bouncing fresh visitors
+  // from SMS / share links to /login when the destination is a public
+  // recruitment surface.
+  if (isPublicPath(req.nextUrl.pathname)) {
+    return NextResponse.next();
+  }
+
   // Check both cookie names so staging (po_session_stg) and production (po_session) both work.
   // Actual session validation happens in getSession() against the correct D1 database.
   const session = req.cookies.get('po_session') || req.cookies.get('po_session_stg');
@@ -24,5 +42,8 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
+  // Matcher must include `/share/:path*` so the vanity-domain rewrite above
+  // can fire on the playtest.peckingorder.ca subdomain even though the path
+  // doesn't start with `/playtest`.
   matcher: ['/', '/join/:path*', '/game/:path*', '/admin/:path*', '/playtest', '/playtest/share/:path*', '/share/:path*'],
 };

--- a/apps/nudge-worker/src/index.ts
+++ b/apps/nudge-worker/src/index.ts
@@ -201,6 +201,19 @@ function bodyLine(text: string): string {
   return `<p style="margin:0 0 28px;font-family:${BODY};font-size:16px;line-height:1.55;color:${TEXT};">${text}</p>`;
 }
 
+/** Stacked-verb statement — brand mantra. Mirrors apps/lobby/lib/email-templates.ts.
+ * Outlook-safe: line-height 1.0 + explicit margin between lines. */
+function verbStack(words: string[], colors?: string[]): string {
+  const palette = colors ?? [TEXT, GOLD, TEXT, CTA];
+  return `<div style="margin:0 0 32px;text-align:center;">${words
+    .map((word, i) => {
+      const color = palette[i % palette.length];
+      const isLast = i === words.length - 1;
+      return `<div style="font-family:${DISPLAY};font-size:52px;font-weight:900;line-height:1.0;letter-spacing:-0.02em;color:${color};text-transform:uppercase;${isLast ? '' : 'margin-bottom:6px;'}">${word}</div>`;
+    })
+    .join('')}</div>`;
+}
+
 function codeBlock(label: string, code: string): string {
   return `<div style="text-align:left;">
     <p style="margin:0 0 6px;font-family:${BODY};font-size:10px;font-weight:700;letter-spacing:3px;text-transform:uppercase;color:${FAINT};">${label}</p>
@@ -241,6 +254,7 @@ export function buildNudgeEmail(target: NudgeTarget, day1Start: Date, lobbyHost:
             ${eyebrow('Starting soon')}
             ${hugeLine(`Day 1 at ${day1Time}`)}
             ${bodyLine('Your cast starts without you if you don&rsquo;t claim a spot. Pick a face and drop in.')}
+            ${verbStack(['Vote.', 'Ally.', 'Betray.', 'Survive.'])}
             ${buttonRow('Claim your spot', joinUrl, 28)}
             ${hairline()}
             ${codeBlock('Invite code', target.inviteCode)}

--- a/docs/reports/pulse-mockups/15-day-shape-pills.html
+++ b/docs/reports/pulse-mockups/15-day-shape-pills.html
@@ -1,0 +1,1545 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Pulse — Day Shape via Pills (v4)</title>
+<link rel="preconnect" href="https://api.fontshare.com">
+<link href="https://api.fontshare.com/v2/css?f[]=clash-display@500,600,700,800,900&f[]=satoshi@400,500,700,900&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #15121a;
+    --surface: #1a1420;
+    --surface-2: #1d1826;
+    --surface-3: #231c2d;
+    --surface-4: #2a2335;
+    --border: rgba(255,255,255,0.06);
+    --border-lifted: rgba(255,255,255,0.10);
+
+    --text-1: #f2eef5;
+    --text-2: #a89fb3;
+    --text-3: #6b5f78;
+    --text-4: #3d3547;
+
+    --accent: #ff3b6f;
+    --accent-g: rgba(255,59,111,0.14);
+    --gold: #ffc83d;
+    --gold-soft: rgba(255,200,61,0.28);
+
+    --k-voting: #4ade80;
+    --k-game:   #fbbf24;
+    --k-prompt: #60a5fa;
+    --k-dilemma:#c084fc;
+    --k-social: #f0d9a8;
+    --k-boundary: #ffc83d;
+
+    --r-sm: 6px; --r-md: 10px; --r-lg: 14px; --r-pill: 100px;
+
+    --font-display: 'Clash Display', system-ui, sans-serif;
+    --font-body: 'Satoshi', system-ui, sans-serif;
+
+    --active-glow-strength: 24px;
+    --active-glow-alpha: 0.55;
+  }
+
+  * { margin:0; padding:0; box-sizing:border-box; -webkit-tap-highlight-color:transparent; }
+  html, body { height:100%; }
+  body {
+    background:
+      radial-gradient(ellipse at top left, rgba(255,200,61,0.03), transparent 45%),
+      radial-gradient(ellipse at bottom right, rgba(255,59,111,0.04), transparent 50%),
+      #08060b;
+    color: var(--text-1);
+    font-family: var(--font-body);
+    min-height: 100vh;
+    padding: 44px 24px 96px;
+  }
+  .page { max-width: 1280px; margin: 0 auto; }
+
+  .page-head { text-align: left; max-width: 760px; margin-bottom: 40px; }
+  .tag {
+    display: inline-block;
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    color: var(--accent);
+    padding: 6px 10px;
+    background: var(--accent-g);
+    border-radius: var(--r-sm);
+    margin-bottom: 14px;
+    text-transform: uppercase;
+  }
+  h1 {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: clamp(36px, 5vw, 56px);
+    line-height: 1.0;
+    letter-spacing: -0.03em;
+    margin-bottom: 14px;
+  }
+  .lede { color: var(--text-2); font-size: 16px; line-height: 1.5; max-width: 640px; }
+  .lede + .lede { margin-top: 8px; }
+
+  section { margin: 56px 0; }
+  .section-head { margin-bottom: 22px; }
+  .section-head .num {
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    color: var(--text-3);
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .section-head h2 {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 28px;
+    letter-spacing: -0.02em;
+    margin-bottom: 8px;
+  }
+  .section-head p { color: var(--text-2); font-size: 14px; line-height: 1.55; max-width: 640px; }
+
+  .stage {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: 28px;
+  }
+
+  /* ---------- Pill ---------- */
+  .pill {
+    --kind: var(--k-voting);
+    --kind-rgb: 74, 222, 128;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 32px;
+    padding: 0 14px;
+    border-radius: var(--r-pill);
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 13px;
+    letter-spacing: 0.01em;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    color: var(--text-2);
+    white-space: nowrap;
+    transition: background 240ms ease, border-color 240ms ease, color 240ms ease, opacity 240ms ease, box-shadow 240ms ease, transform 240ms ease;
+    position: relative;
+    cursor: pointer;
+    user-select: none;
+    flex-shrink: 0;
+  }
+  .pill .ico { width: 14px; height: 14px; display: grid; place-items: center; color: var(--kind); flex-shrink: 0; }
+  .pill .ico svg { width: 100%; height: 100%; }
+  .pill .label { color: inherit; }
+  .pill .meta { color: var(--text-3); font-weight: 500; font-size: 12px; margin-left: 2px; }
+  .pill .lead {
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 8px rgba(255,59,111,0.7);
+    flex-shrink: 0;
+    margin-right: -2px;
+  }
+  .pill .dot {
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--accent);
+    margin-left: 4px;
+    box-shadow: 0 0 0 2px var(--surface);
+    flex-shrink: 0;
+  }
+
+  .pill.is-upcoming {
+    background: transparent;
+    border: 1px solid color-mix(in oklch, var(--kind) 40%, var(--border-lifted));
+    color: var(--text-2);
+    opacity: 1;
+  }
+  .pill.is-upcoming .ico { color: color-mix(in oklch, var(--kind) 60%, var(--text-3)); }
+  .pill.is-upcoming .meta { color: var(--text-3); }
+
+  .pill.is-active {
+    background: color-mix(in oklch, var(--kind) 32%, var(--surface-2));
+    border: 1.5px solid var(--kind);
+    color: var(--text-1);
+    box-shadow:
+      0 0 var(--active-glow-strength) rgba(var(--kind-rgb), var(--active-glow-alpha)),
+      inset 0 0 0 1px rgba(255,255,255,0.04);
+    animation: heartbeat 2.4s ease-in-out infinite;
+  }
+  .pill.is-active .meta { color: var(--text-1); opacity: 0.85; }
+  .pill.is-active.is-just-ignited {
+    animation: ignition 450ms cubic-bezier(0.22, 1, 0.36, 1) 1 forwards,
+               heartbeat 2.4s ease-in-out 450ms infinite;
+  }
+
+  /* Acted: verb-driven (cast / placed / sent / chosen) — no ✓ icon */
+  .pill.is-acted {
+    background: color-mix(in oklch, var(--kind) 12%, var(--surface-2));
+    border: 1px solid color-mix(in oklch, var(--kind) 55%, var(--border));
+    color: var(--text-1);
+    opacity: 1;
+  }
+  .pill.is-acted .meta { color: var(--text-2); }
+  .pill.is-acted .meta .verb {
+    color: var(--kind);
+    font-weight: 700;
+    font-style: italic;
+    font-size: 12px;
+    letter-spacing: 0.01em;
+  }
+  .pill.is-acted .ico { color: var(--kind); }
+
+  .pill.is-urgent {
+    background: color-mix(in oklch, var(--accent) 12%, var(--surface-2));
+    border: 1.5px solid var(--accent);
+    color: var(--accent);
+    box-shadow:
+      0 0 28px rgba(255, 59, 111, 0.65),
+      inset 0 0 0 1px rgba(255,255,255,0.06);
+    animation: urgentPulse 700ms ease-in-out infinite;
+  }
+  .pill.is-urgent .label { color: var(--accent); font-weight: 800; }
+  .pill.is-urgent .meta { color: color-mix(in oklch, var(--accent) 70%, var(--text-1)); }
+  .pill.is-urgent .ico { color: var(--accent); }
+
+  .pill.is-completed-unread {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    color: var(--text-2);
+    opacity: 1;
+  }
+  .pill.is-completed-unread .ico { color: color-mix(in oklch, var(--kind) 60%, var(--text-3)); }
+  .pill.is-completed-unread .label { color: var(--text-1); }
+
+  .pill.is-completed-read {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    color: var(--text-3);
+    opacity: 0.55;
+    padding: 0 9px;
+  }
+  .pill.is-completed-read .ico { opacity: 0.6; }
+  .pill.is-completed-read .label, .pill.is-completed-read .meta { display: none; }
+
+  /* ---------- Boundary pill — mini variant (during day) ---------- */
+  .pill.is-boundary {
+    --kind: var(--k-boundary);
+    --kind-rgb: 255, 200, 61;
+    background: linear-gradient(180deg, rgba(255,200,61,0.10), rgba(255,200,61,0.02));
+    border: 1.5px solid var(--gold-soft);
+    color: var(--gold);
+  }
+  .pill.is-boundary .ico { color: var(--gold); }
+  .pill.is-boundary .label { color: var(--gold); font-weight: 700; letter-spacing: 0.02em; }
+  .pill.is-boundary .meta { color: color-mix(in oklch, var(--gold) 65%, var(--text-2)); }
+  .pill.is-boundary.is-imminent {
+    border-color: var(--gold);
+    box-shadow: 0 0 18px rgba(255,200,61,0.40);
+    animation: heartbeat 2s ease-in-out infinite;
+  }
+
+  /* ---------- Boundary HERO variant (pregame + night) — bolder, default LARGE ---------- */
+  .pill.is-boundary.is-hero {
+    height: 72px;
+    padding: 0 28px;
+    gap: 16px;
+    background:
+      radial-gradient(ellipse at top, rgba(255,200,61,0.20), rgba(255,200,61,0.04) 70%),
+      var(--surface-2);
+    border: 1.5px solid var(--gold);
+    box-shadow:
+      0 0 40px rgba(255,200,61,0.32),
+      inset 0 0 0 1px rgba(255,200,61,0.18),
+      inset 0 -14px 36px rgba(255,200,61,0.06);
+  }
+  .pill.is-boundary.is-hero .ico {
+    width: 26px; height: 26px;
+    color: var(--gold);
+    filter: drop-shadow(0 0 10px rgba(255,200,61,0.60));
+  }
+  .pill.is-boundary.is-hero .hero-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+    line-height: 1;
+  }
+  .pill.is-boundary.is-hero .hero-eyebrow {
+    font-family: var(--font-display);
+    font-size: 11px;
+    font-weight: 900;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: rgba(255,200,61,0.72);
+    line-height: 1;
+    margin-bottom: 6px;
+  }
+  .pill.is-boundary.is-hero .hero-body {
+    font-family: var(--font-display);
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--gold);
+    line-height: 1;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 10px;
+  }
+  .pill.is-boundary.is-hero .hero-rel {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: rgba(255,200,61,0.72);
+  }
+  .pill.is-boundary.is-hero.is-imminent {
+    animation: heroBreathe 1.6s ease-in-out infinite;
+    border-color: #fff0bb;
+  }
+  @keyframes heroBreathe {
+    0%, 100% {
+      box-shadow:
+        0 0 32px rgba(255,200,61,0.30),
+        inset 0 0 0 1px rgba(255,200,61,0.18),
+        inset 0 -10px 28px rgba(255,200,61,0.06);
+    }
+    50% {
+      box-shadow:
+        0 0 56px rgba(255,200,61,0.65),
+        inset 0 0 0 1px rgba(255,200,61,0.32),
+        inset 0 -10px 28px rgba(255,200,61,0.10);
+    }
+  }
+
+  /* ---------- Per-kind hue assignment ---------- */
+  .pill[data-kind="voting"]  { --kind: var(--k-voting);  --kind-rgb: 74, 222, 128; }
+  .pill[data-kind="game"]    { --kind: var(--k-game);    --kind-rgb: 251, 191, 36; }
+  .pill[data-kind="prompt"]  { --kind: var(--k-prompt);  --kind-rgb: 96, 165, 250; }
+  .pill[data-kind="dilemma"] { --kind: var(--k-dilemma); --kind-rgb: 192, 132, 252; }
+  .pill[data-kind="dms"]     { --kind: var(--k-social);  --kind-rgb: 240, 217, 168; }
+  .pill[data-kind="group"]   { --kind: var(--k-social);  --kind-rgb: 240, 217, 168; }
+  .pill[data-kind="boundary"]{ --kind: var(--k-boundary);--kind-rgb: 255, 200, 61; }
+
+  /* ---------- Animations ---------- */
+  @keyframes heartbeat {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.025); }
+  }
+  @keyframes ignition {
+    0% { transform: scale(0.94); }
+    50% { transform: scale(1.08); }
+    100% { transform: scale(1); }
+  }
+  @keyframes urgentPulse {
+    0%, 100% { box-shadow: 0 0 28px rgba(255,59,111,0.55), inset 0 0 0 1px rgba(255,255,255,0.06); }
+    50%      { box-shadow: 0 0 36px rgba(255,59,111,0.85), inset 0 0 0 1px rgba(255,255,255,0.06); }
+  }
+  @keyframes settle {
+    0% { transform: scale(1.04); }
+    100% { transform: scale(1); }
+  }
+  .pill.is-just-settled { animation: settle 500ms cubic-bezier(0.22, 1, 0.36, 1) 1 forwards; }
+
+  @keyframes floatBob {
+    0%, 100% { transform: translateX(-50%) translateY(0); }
+    50% { transform: translateX(-50%) translateY(-3px); }
+  }
+  @keyframes floatBobUrgent {
+    0%, 100% { transform: translateX(-50%) translateY(0) scale(1); }
+    50% { transform: translateX(-50%) translateY(-5px) scale(1.04); }
+  }
+  @keyframes voteUrgentPulse {
+    0%, 100% {
+      box-shadow:
+        0 8px 24px rgba(255,59,111,0.45),
+        0 0 0 4px rgba(255,59,111,0.18);
+    }
+    50% {
+      box-shadow:
+        0 14px 36px rgba(255,59,111,0.85),
+        0 0 0 10px rgba(255,59,111,0.30);
+    }
+  }
+
+  /* ---------- State catalog ---------- */
+  .state-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+  }
+  .state-cell {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    padding: 22px 18px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .state-cell .pill-wrap { min-height: 60px; display: flex; align-items: center; }
+  .state-cell .state-name {
+    font-family: var(--font-display);
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--text-2);
+    font-weight: 800;
+  }
+  .state-cell .state-desc {
+    font-size: 12px;
+    color: var(--text-3);
+    line-height: 1.55;
+  }
+
+  /* ---------- Day stage ---------- */
+  .day-stage { padding: 32px 28px 28px; }
+  .shell-preview {
+    background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    padding: 18px;
+    position: relative;
+    overflow: hidden;
+  }
+  .cast-fake {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 14px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid var(--border);
+    position: relative;
+  }
+  .cast-fake .av {
+    width: 38px; height: 38px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--surface-3), var(--surface-4));
+    border: 1px solid var(--border-lifted);
+    flex-shrink: 0;
+  }
+  .cast-fake .av:nth-child(1) { background: linear-gradient(135deg, #c084fc, #ff3b6f); }
+  .cast-fake .av:nth-child(2) { background: linear-gradient(135deg, #fbbf24, #f87171); }
+  .cast-fake .av:nth-child(3) { background: linear-gradient(135deg, #60a5fa, #34d399); }
+  .cast-fake .av:nth-child(4) { background: linear-gradient(135deg, #a78bfa, #f0d9a8); opacity: 0.5; filter: grayscale(0.6); }
+  .cast-fake .av:nth-child(5) { background: linear-gradient(135deg, #f0d9a8, #fb7185); }
+  .cast-fake .av:nth-child(6) { background: linear-gradient(135deg, #34d399, #60a5fa); }
+  .cast-fake .av:nth-child(7) { background: linear-gradient(135deg, #fbbf24, #c084fc); }
+
+  .chat-fake {
+    margin-top: 18px;
+    padding: 12px 14px;
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    color: var(--text-3);
+    font-size: 14px;
+    position: relative;
+  }
+  .vote-floating {
+    position: absolute;
+    left: 50%;
+    bottom: calc(100% + 10px);
+    transform: translateX(-50%);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    background: var(--accent);
+    color: #1a0710;
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: 13px;
+    letter-spacing: 0.02em;
+    border-radius: var(--r-pill);
+    box-shadow: 0 8px 24px rgba(255,59,111,0.45), 0 0 0 4px rgba(255,59,111,0.16);
+    cursor: pointer;
+    visibility: hidden;
+    animation: floatBob 2.4s ease-in-out infinite;
+  }
+  .vote-floating::before {
+    content: '';
+    width: 7px; height: 7px;
+    background: #1a0710;
+    border-radius: 50%;
+  }
+  .vote-floating.is-on { visibility: visible; }
+  .vote-floating.is-urgent {
+    animation: floatBobUrgent 900ms ease-in-out infinite, voteUrgentPulse 700ms ease-in-out infinite;
+    background: #ff5183;
+    font-size: 14px;
+    padding: 12px 18px;
+  }
+  .vote-floating.is-urgent::before {
+    background: #1a0710;
+    width: 8px; height: 8px;
+    box-shadow: 0 0 0 2px rgba(26,7,16,0.4);
+  }
+
+  /* ---------- Now-line ---------- */
+  .now-line {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 4px 14px 4px;
+    flex-wrap: wrap;
+    font-family: var(--font-display);
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    font-weight: 800;
+    color: var(--text-3);
+  }
+  .now-line .slot { display: flex; align-items: center; gap: 8px; }
+  .now-line .slot .lbl { color: var(--text-3); }
+  .now-line .slot .body { color: var(--text-1); }
+  .now-line.now-faded .slot:first-child .body { color: var(--text-3); }
+  .now-line.now-faded .slot:last-child .lbl,
+  .now-line.now-faded .slot:last-child .body { color: var(--gold); }
+  .now-line.has-urgent .slot:first-child .body,
+  .now-line.has-urgent .slot:first-child .lbl { color: var(--accent); }
+
+  /* ---------- Pill row + edge pin ---------- */
+  .pill-row-wrap {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    padding: 18px 16px;
+    overflow-x: auto;
+    overflow-y: visible;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+    position: relative;
+    min-height: 80px;
+  }
+  .pill-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    min-width: max-content;
+  }
+  .row-frame { position: relative; }
+  .edge-pin {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 4;
+    background: var(--surface-3);
+    border: 1.5px solid var(--accent);
+    color: var(--accent);
+    font-family: var(--font-display);
+    font-size: 12px;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    padding: 8px 12px;
+    border-radius: var(--r-pill);
+    cursor: pointer;
+    box-shadow: 0 4px 18px rgba(255,59,111,0.45), 0 0 0 4px rgba(255,59,111,0.10);
+    display: none;
+    align-items: center;
+    gap: 6px;
+    pointer-events: auto;
+    animation: heartbeat 2s ease-in-out infinite;
+  }
+  .edge-pin.is-on { display: inline-flex; }
+  .edge-pin.at-left  { left: 14px; }
+  .edge-pin.at-right { right: 14px; }
+
+  .now-rail { margin: 22px 0 14px; position: relative; height: 36px; }
+  .now-rail .track {
+    position: absolute; left: 0; right: 0; top: 14px;
+    height: 4px; background: var(--surface-3); border-radius: 2px;
+  }
+  .now-rail .fill {
+    position: absolute; left: 0; top: 14px;
+    height: 4px; background: linear-gradient(90deg, var(--accent), color-mix(in oklch, var(--accent) 50%, var(--gold)));
+    border-radius: 2px; width: 0%;
+  }
+  .now-rail .day-band {
+    position: absolute; top: 12px; height: 8px;
+    background: rgba(255,200,61,0.10);
+    border: 1px solid rgba(255,200,61,0.30);
+    border-radius: 3px;
+  }
+  .scrubber {
+    width: 100%; appearance: none;
+    background: transparent; margin-top: 6px; cursor: ew-resize;
+  }
+  .scrubber::-webkit-slider-runnable-track { height: 4px; background: transparent; }
+  .scrubber::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 24px; height: 24px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 0 3px var(--surface), 0 0 14px rgba(255,59,111,0.55);
+    margin-top: -10px;
+    cursor: ew-resize;
+  }
+
+  .day-meta {
+    display: flex; justify-content: space-between; align-items: baseline;
+    margin-bottom: 10px; gap: 16px; flex-wrap: wrap;
+  }
+  .day-meta .clock {
+    font-family: var(--font-display);
+    font-size: 32px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--text-1);
+  }
+  .day-meta .now-label {
+    font-family: var(--font-display);
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--text-3);
+    font-weight: 800;
+  }
+  .day-meta .phase-tag {
+    font-family: var(--font-display);
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--gold);
+    padding: 4px 10px;
+    border: 1px solid var(--gold-soft);
+    border-radius: var(--r-pill);
+  }
+  .day-meta .phase-tag[data-phase="day"] { color: var(--text-1); border-color: var(--border-lifted); }
+
+  .scrub-actions {
+    display: flex; gap: 10px; margin-top: 18px; flex-wrap: wrap;
+  }
+  .pill-btn {
+    background: var(--surface-3);
+    border: 1px solid var(--border-lifted);
+    color: var(--text-2);
+    font-family: var(--font-body);
+    font-size: 13px;
+    font-weight: 600;
+    padding: 10px 16px;
+    border-radius: var(--r-pill);
+    cursor: pointer;
+    transition: background 180ms ease, color 180ms ease, border-color 180ms ease;
+  }
+  .pill-btn:hover { background: var(--surface-4); color: var(--text-1); }
+  .pill-btn.is-playing {
+    background: var(--accent-g); border-color: var(--accent); color: var(--accent);
+  }
+  .pill-btn.is-tertiary {
+    background: transparent; border: 1px solid var(--border); color: var(--text-3);
+  }
+
+  /* ---------- A/B controls ---------- */
+  .controls-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 16px;
+  }
+  .control {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    padding: 18px;
+  }
+  .control h4 {
+    font-family: var(--font-display);
+    font-size: 11px;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--text-2);
+    font-weight: 800;
+    margin-bottom: 4px;
+  }
+  .control .control-desc {
+    color: var(--text-3); font-size: 12px; line-height: 1.5; margin-bottom: 14px;
+  }
+  .control.is-locked {
+    background: linear-gradient(180deg, rgba(255,200,61,0.04), var(--surface-2));
+    border-color: var(--gold-soft);
+  }
+  .control.is-locked h4::after {
+    content: ' · LOCKED';
+    color: var(--gold);
+    font-size: 10px;
+    letter-spacing: 0.22em;
+  }
+  .seg {
+    display: inline-flex;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-pill);
+    padding: 3px;
+    flex-wrap: wrap;
+    gap: 2px;
+  }
+  .seg button {
+    background: transparent; border: 0;
+    color: var(--text-3);
+    font-family: var(--font-body);
+    font-size: 12px;
+    font-weight: 600;
+    padding: 7px 12px;
+    border-radius: var(--r-pill);
+    cursor: pointer;
+    transition: background 180ms ease, color 180ms ease;
+  }
+  .seg button:hover { color: var(--text-2); }
+  .seg button.is-on { background: var(--accent); color: #1a0710; }
+
+  .notes {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    padding: 22px;
+    margin-top: 16px;
+    color: var(--text-2);
+    font-size: 13px;
+    line-height: 1.6;
+  }
+  .notes b { color: var(--text-1); font-weight: 700; }
+  .notes ul { padding-left: 18px; margin-top: 8px; }
+  .notes li { margin-bottom: 6px; }
+
+  @media (max-width: 720px) {
+    body { padding: 28px 16px 64px; }
+    .stage { padding: 18px; }
+    .day-meta .clock { font-size: 24px; }
+  }
+</style>
+</head>
+<body data-vote-indicator="floating">
+
+<div class="page">
+
+  <header class="page-head">
+    <div class="tag">Mockup · 15 · v5</div>
+    <h1>Pulse — Day shape, told by the pills.</h1>
+    <p class="lede">v5: completed pills now read <code>· result</code> (universal noun) instead of cartridge-specific past-tense — the acted state's verb (<i>cast / placed / sent / chosen</i>) describes <i>your action</i>; the completed state's noun describes <i>the artifact</i>. Different word categories for different concepts; the player's lifecycle no longer reads as two synonyms of the same verb.</p>
+    <p class="lede" style="margin-top:14px;">Hero boundary defaults to large (72px) with bigger typography. Social windows (DMs, group chat) keep their own copy — <i>closed</i> / <i>ended</i> — because they aren't cartridges and don't have results.</p>
+  </header>
+
+  <section>
+    <div class="section-head">
+      <div class="num">01 · Pill state catalog</div>
+      <h2>Six lifecycle states + boundary (mini &amp; hero)</h2>
+      <p>Cartridges run all six states. Social windows skip the action states. Boundary pill comes in two sizes — mini during day, hero in pregame and night.</p>
+    </div>
+    <div class="stage">
+      <div class="state-grid" id="stateGrid"></div>
+    </div>
+    <div class="notes">
+      <b>The verb-vs-noun split (v5):</b> the acted and completed-unread states describe <i>different concepts</i>, so they use <i>different word categories</i>:
+      <ul>
+        <li><b>Acted</b> meta = <b>action verb</b> (<i>cast / placed / sent / chosen</i>) — describes what <i>you</i> did. Tap → review your own submission.</li>
+        <li><b>Completed-unread</b> meta = <b>artifact noun</b> (<i>result</i>) — describes what <i>now exists</i>. Tap → read the all-player result card.</li>
+      </ul>
+      No more "<i>placed</i> → <i>wagered</i>" doublet. Verb stays unique to acted; noun stays unique to completed. They stop competing because they're talking about different things.
+      <br><br>
+      <b>Social windows</b> (DMs, group chat) use <i>closed</i> / <i>ended</i> — they're not cartridges and don't have results. Different word because different concept; consistency within category, distinction between categories.
+      <br><br>
+      Also in v5: hero boundary default is now <b>large (72px)</b>; eyebrow + big "10:00" + relative countdown. Bolder than the previous medium default.
+    </div>
+  </section>
+
+  <section>
+    <div class="section-head">
+      <div class="num">02 · Day shape, in shell context</div>
+      <h2>Pregame → Day → Night</h2>
+      <p>Pregame: only the hero <i>Day starts</i> anchor. Day: chronological pills + mini boundary at right edge. Night: completed pills + hero <i>Day 4 starts</i> anchor. Try the jump buttons and the <i>Sim: act</i> button (acts on the live cartridge so you see verb microcopy).</p>
+    </div>
+
+    <div class="stage day-stage">
+      <div class="day-meta">
+        <div>
+          <div class="now-label">Day 3 · sim clock</div>
+          <div class="clock" id="clock">10:00</div>
+        </div>
+        <div class="phase-tag" id="phaseTag" data-phase="pregame">Pregame</div>
+      </div>
+
+      <div class="shell-preview">
+        <div class="cast-fake" id="castFake">
+          <div class="av"></div><div class="av"></div><div class="av"></div><div class="av"></div><div class="av"></div><div class="av"></div><div class="av"></div>
+        </div>
+
+        <div class="now-line" id="nowLine">
+          <div class="slot"><span class="lbl">Now</span> <span class="body" id="nowBody">—</span></div>
+          <div class="slot"><span class="lbl">Next</span> <span class="body" id="nextBody">—</span></div>
+        </div>
+
+        <div class="row-frame">
+          <div class="pill-row-wrap" id="rowWrap">
+            <div class="pill-row" id="pillRow"></div>
+          </div>
+          <button class="edge-pin" id="edgePin">
+            <span id="edgePinArrow">←</span>
+            <span id="edgePinText">Vote · 4m</span>
+          </button>
+        </div>
+
+        <div class="chat-fake">
+          <span>Type a message…</span>
+          <div class="vote-floating" id="voteFloating">
+            <span id="voteFloatingText">Tap to vote · 4m</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="now-rail">
+        <div class="track"></div>
+        <div class="day-band" id="dayBand"></div>
+        <div class="fill" id="fill"></div>
+        <input class="scrubber" id="scrubber" type="range" min="-60" max="480" value="-30" step="1" aria-label="Scrub day time">
+      </div>
+
+      <div class="scrub-actions">
+        <button class="pill-btn" id="playBtn">▶ Play 12×</button>
+        <button class="pill-btn" data-jump="-30">9:30 · pregame</button>
+        <button class="pill-btn" data-jump="-2">9:58 · imminent</button>
+        <button class="pill-btn" data-jump="0">10:00 · day open</button>
+        <button class="pill-btn" data-jump="200">13:20 · midday</button>
+        <button class="pill-btn" data-jump="305">15:05 · vote opens</button>
+        <button class="pill-btn" data-jump="414">16:54 · vote urgent</button>
+        <button class="pill-btn" data-jump="430">17:10 · night</button>
+        <button class="pill-btn is-tertiary" id="actBtn">Sim: act on the live cartridge</button>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <div class="section-head">
+      <div class="num">03 · Decisions</div>
+      <h2>Locked + still open</h2>
+      <p>Locked items shown for traceability; toggles still work for recompare.</p>
+    </div>
+
+    <div class="controls-grid">
+
+      <div class="control is-locked">
+        <h4>Voting indicator</h4>
+        <div class="control-desc">Floating chip above the chat input, with a distinct urgent state (faster bob + bolder shadow swing).</div>
+        <div class="seg" data-control="vote-indicator">
+          <button data-val="floating" class="is-on">Floating chip</button>
+          <button data-val="none">None (pill only)</button>
+        </div>
+      </div>
+
+      <div class="control is-locked">
+        <h4>Active glow strength</h4>
+        <div class="control-desc">Strong (24px @ 0.55).</div>
+        <div class="seg" data-control="active-glow">
+          <button data-val="subtle">Subtle</button>
+          <button data-val="standard">Standard</button>
+          <button data-val="strong" class="is-on">Strong</button>
+        </div>
+      </div>
+
+      <div class="control is-locked">
+        <h4>Past-pill density</h4>
+        <div class="control-desc">Mini (icon-only) once read.</div>
+        <div class="seg" data-control="past-density">
+          <button data-val="mini" class="is-on">Mini</button>
+          <button data-val="full">Full</button>
+        </div>
+      </div>
+
+      <div class="control is-locked">
+        <h4>Social-window hue</h4>
+        <div class="control-desc">DMs + group chat share cream — distinct from cartridges.</div>
+        <div class="seg" data-control="social-hue">
+          <button data-val="cream" class="is-on">Cream</button>
+          <button data-val="warm-grey">Warm grey</button>
+          <button data-val="dusk">Dusk-rose</button>
+        </div>
+      </div>
+
+      <div class="control">
+        <h4>Boundary copy (day-end)</h4>
+        <div class="control-desc">How does the day-end pill read during the day phase?</div>
+        <div class="seg" data-control="boundary-copy">
+          <button data-val="ends" class="is-on">Day ends</button>
+          <button data-val="closes">Day closes</button>
+          <button data-val="lights">Lights out</button>
+        </div>
+      </div>
+
+      <div class="control">
+        <h4>Hero size</h4>
+        <div class="control-desc">How big is the pregame/night anchor?</div>
+        <div class="seg" data-control="hero-size">
+          <button data-val="large" class="is-on">Large (72px)</button>
+          <button data-val="medium">Medium (56px)</button>
+          <button data-val="small">Small (44px)</button>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="notes" style="margin-top:24px;">
+      <b>Still open:</b>
+      <ul>
+        <li><b>Eliminated cast</b> — out players still see the row. Voting/game pills they can't act on: full but desaturated, or mini regardless of state?</li>
+        <li><b>Multiple simultaneous active cartridges</b> — at noon, dilemma + DMs + group + (later) wager + prompt are all live. Cap concurrent glows, or trust per-pill priority?</li>
+        <li><b>Whispers</b> — currently a separate cartridge kind in Pulse with its own violet hue. Folding into the social-window cream means losing that distinction. Confirm intended, or whispers stay violet-as-cartridge.</li>
+        <li><b>Misspelling at <code>timeline-presets.ts:137</code></b> (<code>START_ACTIVITY</code> where <code>END_ACTIVITY</code> is meant) — fix in this branch.</li>
+      </ul>
+    </div>
+  </section>
+
+</div>
+
+<script>
+  function h(tag, props, children) {
+    const el = document.createElement(tag);
+    if (props) {
+      for (const k of Object.keys(props)) {
+        if (k === 'class') el.className = props[k];
+        else if (k === 'text') el.textContent = props[k];
+        else if (k === 'style') Object.assign(el.style, props[k]);
+        else if (k.startsWith('on')) el.addEventListener(k.slice(2).toLowerCase(), props[k]);
+        else el.setAttribute(k, props[k]);
+      }
+    }
+    if (children) {
+      for (const c of children) {
+        if (c == null || c === false) continue;
+        el.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+      }
+    }
+    return el;
+  }
+  function clear(el) { while (el.firstChild) el.removeChild(el.firstChild); }
+
+  const ICON_SRC = {
+    voting:  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"/></svg>',
+    game:    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M21 6H3a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2zM10 13H8v2H6v-2H4v-2h2V9h2v2h2zm4.5 1a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm4-3a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"/></svg>',
+    prompt:  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M20 2H4a2 2 0 0 0-2 2v18l4-4h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zm-7 12h-2v-2h2zm0-4h-2V6h2z"/></svg>',
+    dilemma: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2 2 22h20zm-1 6v6h2V8zm0 8v2h2v-2z"/></svg>',
+    dms:     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M20 2H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2h3l3 3 3-3h7a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zM7 9h10v2H7zm0 4h7v2H7z"/></svg>',
+    group:   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M16 11a3 3 0 1 0-3-3 3 3 0 0 0 3 3zm-8 0a3 3 0 1 0-3-3 3 3 0 0 0 3 3zm0 2c-2.7 0-8 1.3-8 4v3h16v-3c0-2.7-5.3-4-8-4zm8 0c-.4 0-.8 0-1.2.1A5.6 5.6 0 0 1 18 17v3h6v-3c0-2.7-5.3-4-8-4z"/></svg>',
+    boundary:'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 1a11 11 0 1 0 11 11A11 11 0 0 0 12 1zm0 20a9 9 0 1 1 9-9 9 9 0 0 1-9 9zm0-15v6l4 2"/></svg>',
+  };
+  function svgNode(kind) {
+    const src = ICON_SRC[kind];
+    if (!src) return document.createTextNode('');
+    const doc = new DOMParser().parseFromString(src, 'image/svg+xml');
+    return document.importNode(doc.documentElement, true);
+  }
+
+  // ---------- Formatters ----------
+  // fmtCountdown — standalone, has trailing "left"
+  function fmtCountdown(mins) {
+    const m = Math.max(0, mins);
+    const mInt = Math.floor(m);
+    const sInt = Math.max(0, Math.floor((m - mInt) * 60));
+    if (m < 60) return `${mInt}m ${String(sInt).padStart(2,'0')}s left`;
+    const hh = Math.floor(mInt / 60);
+    const mm = mInt % 60;
+    return `${hh}h ${String(mm).padStart(2,'0')}m left`;
+  }
+  // fmtRelative — used after "in" prefix; no trailing "left"
+  function fmtRelative(mins) {
+    const m = Math.max(0, mins);
+    const mInt = Math.floor(m);
+    const sInt = Math.max(0, Math.floor((m - mInt) * 60));
+    if (m < 1) return `${sInt}s`;
+    if (m < 60) return `${mInt}m`;
+    const hh = Math.floor(mInt / 60);
+    const mm = mInt % 60;
+    if (mm === 0) return `${hh}h`;
+    return `${hh}h ${String(mm).padStart(2,'0')}m`;
+  }
+
+  function clockLabel(t) {
+    const totalMin = 600 + Math.floor(t);
+    const inDay = ((totalMin % 1440) + 1440) % 1440;
+    const hh = Math.floor(inDay / 60);
+    const mm = inDay % 60;
+    return `${String(hh).padStart(2,'0')}:${String(mm).padStart(2,'0')}`;
+  }
+  function phaseFor(t) {
+    if (t < 0) return 'pregame';
+    if (t > 420) return 'night';
+    return 'day';
+  }
+
+  // ---------- Pill builder ----------
+  function pill({ kind, label, meta, state, dot, mini, lead, title, isBoundary, isHero, hero }) {
+    const cls = ['pill'];
+    if (state) cls.push('is-' + state);
+    if (mini) cls.push('is-mini');
+    if (isBoundary) cls.push('is-boundary');
+    if (isHero) cls.push('is-hero');
+    if (state === 'completed-unread' || state === 'completed-read') cls.push('is-past-completed');
+
+    const children = [];
+    if (lead) children.push(h('span', { class: 'lead', 'aria-hidden': 'true' }));
+    children.push(h('span', { class: 'ico', 'aria-hidden': 'true' }, [svgNode(kind)]));
+
+    if (isHero && hero) {
+      const stack = h('div', { class: 'hero-stack' }, [
+        h('span', { class: 'hero-eyebrow' }, [hero.eyebrow]),
+        h('span', { class: 'hero-body' }, [
+          hero.body,
+          hero.rel ? h('span', { class: 'hero-rel' }, ['in ' + hero.rel]) : null,
+        ].filter(Boolean)),
+      ]);
+      children.push(stack);
+    } else {
+      children.push(h('span', { class: 'label' }, [label]));
+      children.push(h('span', { class: 'meta' }, meta ? ['· ' + meta] : []));
+    }
+
+    if (dot) children.push(h('span', { class: 'dot', 'aria-hidden': 'true' }));
+
+    const btn = h('button', { class: cls.join(' '), 'data-kind': kind }, children);
+    if (title) btn.setAttribute('title', title);
+    return btn;
+  }
+
+  // Same as pill() but the meta carries a verb-styled span for acted state
+  function actedPill({ kind, label, verb, countdown }) {
+    const btn = h('button', { class: 'pill is-acted', 'data-kind': kind }, [
+      h('span', { class: 'ico', 'aria-hidden': 'true' }, [svgNode(kind)]),
+      h('span', { class: 'label' }, [label]),
+      h('span', { class: 'meta' }, [
+        '· ',
+        h('span', { class: 'verb' }, [verb]),
+        ' · ' + countdown,
+      ]),
+    ]);
+    return btn;
+  }
+
+  // ---------- State catalog ----------
+  function buildStateGrid() {
+    const grid = document.getElementById('stateGrid');
+    clear(grid);
+
+    const cells = [
+      {
+        node: pill({ kind: 'voting', label: 'Vote', meta: '16:00', state: 'upcoming' }),
+        name: 'Upcoming',
+        desc: 'Solid kind-color border at 40%. The future is already coloured-in.',
+      },
+      {
+        node: pill({ kind: 'prompt', label: 'Prompt', meta: '12m 00s left', state: 'active' }),
+        name: 'Active',
+        desc: 'Cartridge open, you haven\'t acted. Kind glow + breathing.',
+      },
+      {
+        node: actedPill({ kind: 'prompt', label: 'Prompt', verb: 'sent', countdown: '8m 00s left' }),
+        name: 'Acted',
+        desc: 'Verb microcopy carries the meaning — no ✓ icon to clash with past-tense in completed states.',
+      },
+      {
+        node: pill({ kind: 'voting', label: 'Vote now', meta: '4m 00s left', state: 'urgent', lead: true }),
+        name: 'Urgent',
+        desc: 'Closing soon AND you haven\'t acted. Accent-pink ring; kind glow dropped.',
+      },
+      {
+        node: pill({ kind: 'game', label: 'Wager', meta: 'result', state: 'completed-unread', dot: true }),
+        name: 'Completed · unread',
+        desc: 'Cartridge tallied. Universal noun "result" — different word category from the acted-state verb to keep them visually and verbally distinct.',
+      },
+      {
+        node: pill({ kind: 'dilemma', label: 'Dilemma', state: 'completed-read', mini: true, title: 'Dilemma · result' }),
+        name: 'Completed · read',
+        desc: 'Mini, dim. Icon-only. Tooltip on hover: "Dilemma · result".',
+      },
+      {
+        node: pill({ kind: 'dms', label: 'DMs', meta: '11:00', state: 'upcoming' }),
+        name: 'Social window · upcoming',
+        desc: 'Cream hue, shared with whispers + group chat. No urgent / acted / unread states.',
+      },
+      {
+        node: pill({ kind: 'group', label: 'Group', meta: 'open · ends 12:00', state: 'active' }),
+        name: 'Social window · active',
+        desc: 'Same active glow treatment, cream hue.',
+      },
+      {
+        node: pill({ kind: 'boundary', label: 'Day ends', meta: '17:00 · in 12m', state: 'upcoming', isBoundary: true }),
+        name: 'Boundary · mini',
+        desc: 'Used during the day, anchored at the right edge of the row. Gold gradient.',
+      },
+      {
+        node: pill({ kind: 'boundary', state: 'upcoming', isBoundary: true, isHero: true,
+                    hero: { eyebrow: 'Day 1 starts', body: '10:00', rel: '5m 32s' } }),
+        name: 'Boundary · hero',
+        desc: 'Used in pregame and night. Two-line layout, gold glow that breathes when imminent.',
+      },
+    ];
+
+    cells.forEach((c) => {
+      grid.appendChild(h('div', { class: 'state-cell' }, [
+        h('div', { class: 'pill-wrap' }, [c.node]),
+        h('div', null, [
+          h('div', { class: 'state-name' }, [c.name]),
+          h('div', { class: 'state-desc' }, [c.desc]),
+        ]),
+      ]));
+    });
+  }
+
+  // ---------- Day timeline ----------
+  // hasAct + actVerb: the past-tense action verb shown during ACTED state.
+  const DAY_EVENTS = [
+    { id: 'group-1', kind: 'group',   label: 'Group',   start: 0,   end: 120, hasAct: false, socialWindow: true,  copyUpcoming: '10:00', copyActiveLong: 'open · ends 12:00', pastTense: 'ended' },
+    { id: 'dilemma', kind: 'dilemma', label: 'Dilemma', start: 1,   end: 299, hasAct: true,  socialWindow: false, copyUpcoming: '10:01', copyActiveLong: 'ends 14:59',         pastTense: 'chosen', actVerb: 'chosen', simActedAt: 60 },
+    { id: 'dms-1',   kind: 'dms',     label: 'DMs',     start: 60,  end: 360, hasAct: false, socialWindow: true,  copyUpcoming: '11:00', copyActiveLong: 'ends 16:00',         pastTense: 'closed' },
+    { id: 'game',    kind: 'game',    label: 'Wager',   start: 121, end: 240, hasAct: true,  socialWindow: false, copyUpcoming: '12:01', copyActiveLong: null,                 pastTense: 'wagered', actVerb: 'placed', simActedAt: 200 },
+    { id: 'prompt',  kind: 'prompt',  label: 'Prompt',  start: 122, end: 302, hasAct: true,  socialWindow: false, copyUpcoming: '12:02', copyActiveLong: 'ends 15:02',         pastTense: 'sent',    actVerb: 'sent',   simActedAt: 220 },
+    { id: 'group-2', kind: 'group',   label: 'Group',   start: 300, end: 361, hasAct: false, socialWindow: true,  copyUpcoming: '15:00', copyActiveLong: 'open · ends 16:01',  pastTense: 'ended' },
+    { id: 'voting',  kind: 'voting',  label: 'Vote',    start: 301, end: 419, hasAct: true,  socialWindow: false, copyUpcoming: '15:01', copyActiveLong: null,                 pastTense: 'voted',   actVerb: 'cast',   urgentBefore: 8 },
+  ];
+
+  const playerActed = new Map();
+  let actSimUsed = false;
+
+  function deriveState(ev, t) {
+    if (t < ev.start) return 'upcoming';
+    if (t >= ev.end) {
+      if (ev.socialWindow) return (t - ev.end > 5) ? 'completed-read' : 'completed-unread';
+      return (t - ev.end > 30) ? 'completed-read' : 'completed-unread';
+    }
+    if (ev.urgentBefore && (ev.end - t) <= ev.urgentBefore && !playerActed.get(ev.id)) return 'urgent';
+    if (ev.hasAct && playerActed.get(ev.id)) return 'acted';
+    return 'active';
+  }
+
+  // ---------- Build row ----------
+  const row = document.getElementById('pillRow');
+  const rowWrap = document.getElementById('rowWrap');
+  const pillNodes = new Map();
+  const prevState = new Map();
+  let boundaryNode = null;
+
+  function buildRow() {
+    clear(row);
+    pillNodes.clear();
+    DAY_EVENTS.forEach((ev) => {
+      const node = pill({ kind: ev.kind, label: ev.label, meta: '', state: 'upcoming' });
+      node.dataset.id = ev.id;
+      row.appendChild(node);
+      pillNodes.set(ev.id, node);
+    });
+    // Boundary placeholder — content rebuilt every tick by updateBoundary
+    boundaryNode = h('button', { class: 'pill is-boundary', 'data-kind': 'boundary', 'data-id': 'boundary' });
+    row.appendChild(boundaryNode);
+  }
+
+  function getBoundaryCopy() {
+    const seg = document.querySelector('.seg[data-control="boundary-copy"]');
+    if (!seg) return 'Day ends';
+    const on = seg.querySelector('button.is-on');
+    if (!on) return 'Day ends';
+    if (on.dataset.val === 'closes') return 'Day closes';
+    if (on.dataset.val === 'lights') return 'Lights out';
+    return 'Day ends';
+  }
+  function getHeroSize() {
+    const seg = document.querySelector('.seg[data-control="hero-size"]');
+    if (!seg) return 'large';
+    const on = seg.querySelector('button.is-on');
+    return on ? on.dataset.val : 'large';
+  }
+
+  function rebuildBoundary(t) {
+    if (!boundaryNode) return;
+    clear(boundaryNode);
+    boundaryNode.classList.remove('is-imminent', 'is-hero');
+    boundaryNode.style.removeProperty('height');
+    boundaryNode.style.removeProperty('padding');
+
+    const phase = phaseFor(t);
+    const size = getHeroSize();
+
+    if (phase === 'pregame') {
+      const minsTo = 0 - t;
+      boundaryNode.classList.add('is-hero');
+      if (minsTo < 5) boundaryNode.classList.add('is-imminent');
+      // Default = large (72px) from CSS; override for medium / small
+      if (size === 'medium') { boundaryNode.style.height = '56px'; boundaryNode.style.padding = '0 22px'; }
+      if (size === 'small')  { boundaryNode.style.height = '44px'; boundaryNode.style.padding = '0 16px'; }
+      boundaryNode.appendChild(h('span', { class: 'ico', 'aria-hidden': 'true' }, [svgNode('boundary')]));
+      boundaryNode.appendChild(h('div', { class: 'hero-stack' }, [
+        h('span', { class: 'hero-eyebrow' }, ['Day 1 starts']),
+        h('span', { class: 'hero-body' }, [
+          '10:00',
+          h('span', { class: 'hero-rel' }, ['in ' + fmtRelative(minsTo)]),
+        ]),
+      ]));
+    } else if (phase === 'night') {
+      // Day 4 starts 24h after t=0, i.e., t=1440. We're past 420.
+      const remaining = 1440 - t;
+      boundaryNode.classList.add('is-hero');
+      if (remaining < 5) boundaryNode.classList.add('is-imminent');
+      if (size === 'medium') { boundaryNode.style.height = '56px'; boundaryNode.style.padding = '0 22px'; }
+      if (size === 'small')  { boundaryNode.style.height = '44px'; boundaryNode.style.padding = '0 16px'; }
+      boundaryNode.appendChild(h('span', { class: 'ico', 'aria-hidden': 'true' }, [svgNode('boundary')]));
+      boundaryNode.appendChild(h('div', { class: 'hero-stack' }, [
+        h('span', { class: 'hero-eyebrow' }, ['Day 4 starts']),
+        h('span', { class: 'hero-body' }, [
+          '10:00',
+          h('span', { class: 'hero-rel' }, ['in ' + fmtRelative(remaining)]),
+        ]),
+      ]));
+    } else {
+      const minsTo = 420 - t;
+      if (minsTo < 15) boundaryNode.classList.add('is-imminent');
+      boundaryNode.appendChild(h('span', { class: 'ico', 'aria-hidden': 'true' }, [svgNode('boundary')]));
+      boundaryNode.appendChild(h('span', { class: 'label' }, [getBoundaryCopy()]));
+      boundaryNode.appendChild(h('span', { class: 'meta' }, ['· 17:00 · in ' + fmtRelative(minsTo)]));
+    }
+  }
+
+  function updatePillNode(ev, state, t) {
+    const node = pillNodes.get(ev.id);
+    if (!node) return;
+
+    // Pregame: hide all cartridge / window pills
+    const phase = phaseFor(t);
+    if (phase === 'pregame') {
+      node.style.display = 'none';
+      return;
+    } else {
+      node.style.display = '';
+    }
+
+    clear(node);
+
+    const showLead = state === 'urgent';
+    const showDot = state === 'completed-unread' && !ev.socialWindow;
+    const isMini = state === 'completed-read';
+
+    ['is-upcoming','is-active','is-acted','is-urgent','is-completed-unread','is-completed-read','is-mini','is-past-completed','is-just-ignited','is-just-settled']
+      .forEach((c) => node.classList.remove(c));
+    node.classList.add('is-' + state);
+    if (isMini) node.classList.add('is-mini');
+    if (state === 'completed-unread' || state === 'completed-read') node.classList.add('is-past-completed');
+
+    if (showLead) node.appendChild(h('span', { class: 'lead', 'aria-hidden': 'true' }));
+    node.appendChild(h('span', { class: 'ico', 'aria-hidden': 'true' }, [svgNode(ev.kind)]));
+
+    let labelText = ev.label;
+    if (state === 'urgent' && ev.kind === 'voting') labelText = 'Vote now';
+    node.appendChild(h('span', { class: 'label' }, [labelText]));
+
+    let metaChildren = [];
+    if (state === 'upcoming') {
+      metaChildren = ['· ' + ev.copyUpcoming];
+    } else if (state === 'active' || state === 'urgent') {
+      const minsLeft = ev.end - t;
+      if (ev.copyActiveLong && minsLeft > 60 && state !== 'urgent') {
+        metaChildren = ['· ' + ev.copyActiveLong];
+      } else {
+        metaChildren = ['· ' + fmtCountdown(minsLeft)];
+      }
+    } else if (state === 'acted') {
+      const minsLeft = ev.end - t;
+      metaChildren = [
+        '· ',
+        h('span', { class: 'verb' }, [ev.actVerb || 'in']),
+        ' · ' + fmtCountdown(minsLeft),
+      ];
+    } else if (state === 'completed-unread') {
+      // Cartridges → universal noun "result" (artifact). Social windows → "closed"/"ended" (window state).
+      metaChildren = ['· ' + (ev.socialWindow ? ev.pastTense : 'result')];
+    } else if (state === 'completed-read') {
+      metaChildren = ['· ' + (ev.socialWindow ? ev.pastTense : 'result')];
+    }
+
+    node.appendChild(h('span', { class: 'meta' }, metaChildren));
+
+    if (showDot) node.appendChild(h('span', { class: 'dot', 'aria-hidden': 'true' }));
+
+    if (state === 'completed-read') {
+      const tooltipNoun = ev.socialWindow ? ev.pastTense : 'result';
+      node.setAttribute('title', `${ev.label} · ${tooltipNoun}`);
+    } else node.removeAttribute('title');
+  }
+
+  let lastSnappedId = null;
+
+  function applyRow(t) {
+    DAY_EVENTS.forEach((ev) => {
+      if (ev.hasAct && !playerActed.get(ev.id) && ev.simActedAt && t >= ev.simActedAt && !actSimUsed) {
+        playerActed.set(ev.id, true);
+      }
+      const state = deriveState(ev, t);
+      const wasState = prevState.get(ev.id);
+      updatePillNode(ev, state, t);
+      const node = pillNodes.get(ev.id);
+      if (wasState && wasState !== state) {
+        if (wasState === 'upcoming' && (state === 'active' || state === 'urgent')) {
+          node.classList.add('is-just-ignited');
+        }
+        if ((wasState === 'active' || wasState === 'urgent' || wasState === 'acted') && state.indexOf('completed') === 0) {
+          node.classList.add('is-just-settled');
+        }
+      }
+      prevState.set(ev.id, state);
+    });
+    rebuildBoundary(t);
+
+    const mostUrgent = DAY_EVENTS.find(ev => deriveState(ev, t) === 'urgent')
+      || DAY_EVENTS.find(ev => deriveState(ev, t) === 'active' && !ev.socialWindow);
+    if (mostUrgent && lastSnappedId !== mostUrgent.id) {
+      const node = pillNodes.get(mostUrgent.id);
+      if (node) {
+        const wrapRect = rowWrap.getBoundingClientRect();
+        const aRect = node.getBoundingClientRect();
+        const targetLeft = rowWrap.scrollLeft + (aRect.left - wrapRect.left) - (rowWrap.clientWidth / 2) + (aRect.width / 2);
+        rowWrap.scrollTo({ left: targetLeft, behavior: 'smooth' });
+        lastSnappedId = mostUrgent.id;
+      }
+    }
+    if (!mostUrgent) lastSnappedId = null;
+
+    updateEdgePin(t);
+  }
+
+  // ---------- Now-line ----------
+  function updateNowLine(t) {
+    const nowLine = document.getElementById('nowLine');
+    const nowBody = document.getElementById('nowBody');
+    const nextBody = document.getElementById('nextBody');
+    nowLine.classList.remove('has-urgent', 'now-faded');
+
+    const phase = phaseFor(t);
+
+    if (phase === 'pregame') {
+      const minsTo = 0 - t;
+      nowBody.textContent = `Pregame · starts in ${fmtRelative(minsTo)}`;
+      nextBody.textContent = `Day 3 · 10:00`;
+      nowLine.classList.add('now-faded');
+      return;
+    }
+    if (phase === 'night') {
+      nowBody.textContent = 'Night · day closed';
+      const remaining = 1440 - t;
+      nextBody.textContent = `Day 4 · 10:00 · in ${fmtRelative(remaining)}`;
+      nowLine.classList.add('now-faded');
+      return;
+    }
+
+    const states = DAY_EVENTS.map(ev => ({ ev, st: deriveState(ev, t) }));
+    const urgent = states.find(s => s.st === 'urgent');
+    const activeCart = states.find(s => s.st === 'active' && !s.ev.socialWindow);
+    const actedCart  = states.find(s => s.st === 'acted');
+    const window     = states.find(s => s.st === 'active' && s.ev.socialWindow);
+    const primary = urgent || activeCart || actedCart || window;
+
+    if (urgent) nowLine.classList.add('has-urgent');
+
+    if (primary) {
+      const minsLeft = primary.ev.end - t;
+      const tail = (primary.ev.copyActiveLong && minsLeft > 60 && !urgent)
+        ? primary.ev.copyActiveLong
+        : fmtCountdown(minsLeft);
+      nowBody.textContent = `${primary.ev.label} · ${tail}`;
+    } else {
+      nowBody.textContent = 'Day clear';
+    }
+
+    const isPassiveLong = primary && primary.ev.socialWindow && (primary.ev.end - t) > 60;
+    if (isPassiveLong && !urgent) nowLine.classList.add('now-faded');
+
+    const next = DAY_EVENTS.find(ev => ev.start > t);
+    if (next) {
+      const minsTo = next.start - t;
+      const tail = (minsTo < 60) ? `in ${fmtRelative(minsTo)}` : `${clockLabel(next.start)}`;
+      nextBody.textContent = `${next.label} · ${tail}`;
+    } else {
+      const minsTo = 420 - t;
+      nextBody.textContent = `Day ends · in ${fmtRelative(minsTo)}`;
+    }
+  }
+
+  // ---------- Voting indicator ----------
+  function updateVoteIndicator(t) {
+    const voteEv = DAY_EVENTS.find(e => e.kind === 'voting');
+    const voteState = voteEv ? deriveState(voteEv, t) : 'upcoming';
+    const isVoteOpen = voteState === 'active' || voteState === 'urgent' || voteState === 'acted';
+    const isVoteUrgent = voteState === 'urgent';
+    const hasActed = !!playerActed.get('voting');
+
+    const floating = document.getElementById('voteFloating');
+    const floatingText = document.getElementById('voteFloatingText');
+
+    floating.classList.toggle('is-on', isVoteOpen);
+    floating.classList.toggle('is-urgent', isVoteUrgent);
+
+    if (isVoteOpen) {
+      const minsLeft = voteEv.end - t;
+      let text;
+      if (hasActed) text = `Vote cast · ${fmtCountdown(minsLeft)}`;
+      else if (isVoteUrgent) text = `Vote closing · ${fmtCountdown(minsLeft)}`;
+      else text = `Tap to vote · ${fmtCountdown(minsLeft)}`;
+      floatingText.textContent = text;
+    }
+  }
+
+  // ---------- Edge pin ----------
+  function updateEdgePin(t) {
+    const pin = document.getElementById('edgePin');
+    const arrow = document.getElementById('edgePinArrow');
+    const text = document.getElementById('edgePinText');
+
+    const target = DAY_EVENTS.find(ev => deriveState(ev, t) === 'urgent')
+      || DAY_EVENTS.find(ev => deriveState(ev, t) === 'active' && !ev.socialWindow);
+
+    if (!target) { pin.classList.remove('is-on'); return; }
+    const node = pillNodes.get(target.id);
+    if (!node || node.style.display === 'none') { pin.classList.remove('is-on'); return; }
+
+    const wrapRect = rowWrap.getBoundingClientRect();
+    const aRect = node.getBoundingClientRect();
+    const visible = aRect.right > wrapRect.left + 24 && aRect.left < wrapRect.right - 24;
+
+    if (visible) {
+      pin.classList.remove('is-on');
+      pin.removeAttribute('data-pin-target');
+    } else {
+      pin.classList.add('is-on');
+      pin.classList.toggle('at-left', aRect.left < wrapRect.left);
+      pin.classList.toggle('at-right', aRect.left > wrapRect.left);
+      arrow.textContent = (aRect.left < wrapRect.left) ? '←' : '→';
+      const minsLeft = target.end - t;
+      text.textContent = `${target.label} · ${fmtCountdown(minsLeft)}`;
+      pin.setAttribute('data-pin-target', target.id);
+    }
+  }
+  rowWrap.addEventListener('scroll', () => updateEdgePin(parseFloat(scrubber.value)));
+  document.getElementById('edgePin').addEventListener('click', () => {
+    const id = document.getElementById('edgePin').getAttribute('data-pin-target');
+    if (!id) return;
+    const node = pillNodes.get(id);
+    if (!node) return;
+    const wrapRect = rowWrap.getBoundingClientRect();
+    const aRect = node.getBoundingClientRect();
+    const targetLeft = rowWrap.scrollLeft + (aRect.left - wrapRect.left) - (rowWrap.clientWidth / 2) + (aRect.width / 2);
+    rowWrap.scrollTo({ left: targetLeft, behavior: 'smooth' });
+  });
+
+  function updatePhaseTag(t) {
+    const tag = document.getElementById('phaseTag');
+    const phase = phaseFor(t);
+    tag.dataset.phase = phase;
+    if (phase === 'pregame') tag.textContent = 'Pregame';
+    else if (phase === 'night') tag.textContent = 'Night';
+    else tag.textContent = 'Day 3';
+  }
+
+  function setupDayBand() {
+    const band = document.getElementById('dayBand');
+    const min = -60, max = 480, range = max - min;
+    band.style.left = (((0 - min) / range) * 100) + '%';
+    band.style.width = (((420 - 0) / range) * 100) + '%';
+  }
+
+  // ---------- Scrubber ----------
+  const scrubber = document.getElementById('scrubber');
+  const fill = document.getElementById('fill');
+  const clock = document.getElementById('clock');
+  function setT(t) {
+    scrubber.value = t;
+    const min = -60, max = 480, range = max - min;
+    fill.style.width = (((t - min) / range) * 100) + '%';
+    clock.textContent = clockLabel(t);
+    applyRow(t);
+    updateNowLine(t);
+    updateVoteIndicator(t);
+    updatePhaseTag(t);
+  }
+  scrubber.addEventListener('input', () => setT(parseInt(scrubber.value, 10)));
+  document.querySelectorAll('[data-jump]').forEach((b) => {
+    b.addEventListener('click', () => setT(parseInt(b.dataset.jump, 10)));
+  });
+
+  document.getElementById('actBtn').addEventListener('click', () => {
+    actSimUsed = true;
+    const t = parseFloat(scrubber.value);
+    const target = DAY_EVENTS.find(ev => ev.hasAct && (deriveState(ev, t) === 'active' || deriveState(ev, t) === 'urgent'));
+    if (target) {
+      playerActed.set(target.id, true);
+      setT(t);
+    }
+  });
+
+  const playBtn = document.getElementById('playBtn');
+  let playing = false; let playRAF = null; let lastTick = 0;
+  function loop(ts) {
+    if (!playing) return;
+    if (!lastTick) lastTick = ts;
+    const dt = (ts - lastTick) / 1000;
+    lastTick = ts;
+    let v = parseFloat(scrubber.value) + dt * 12;
+    if (v >= 480) {
+      v = 480; playing = false;
+      playBtn.classList.remove('is-playing'); playBtn.textContent = '▶ Play 12×';
+    }
+    setT(v);
+    if (playing) playRAF = requestAnimationFrame(loop);
+  }
+  playBtn.addEventListener('click', () => {
+    playing = !playing;
+    if (playing) {
+      if (parseFloat(scrubber.value) >= 480) {
+        playerActed.clear(); actSimUsed = false; setT(-60);
+      }
+      lastTick = 0;
+      playBtn.classList.add('is-playing'); playBtn.textContent = '❚❚ Pause';
+      playRAF = requestAnimationFrame(loop);
+    } else {
+      playBtn.classList.remove('is-playing'); playBtn.textContent = '▶ Play 12×';
+      cancelAnimationFrame(playRAF);
+    }
+  });
+
+  // ---------- A/B ----------
+  document.querySelectorAll('.seg').forEach((seg) => {
+    const ctrl = seg.dataset.control;
+    seg.querySelectorAll('button').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        seg.querySelectorAll('button').forEach(b => b.classList.remove('is-on'));
+        btn.classList.add('is-on');
+        const val = btn.dataset.val;
+        if (ctrl === 'active-glow') {
+          if (val === 'subtle')   { document.documentElement.style.setProperty('--active-glow-strength', '8px');  document.documentElement.style.setProperty('--active-glow-alpha', '0.28'); }
+          if (val === 'standard') { document.documentElement.style.setProperty('--active-glow-strength', '14px'); document.documentElement.style.setProperty('--active-glow-alpha', '0.40'); }
+          if (val === 'strong')   { document.documentElement.style.setProperty('--active-glow-strength', '24px'); document.documentElement.style.setProperty('--active-glow-alpha', '0.55'); }
+        } else if (ctrl === 'past-density') {
+          document.body.dataset.pastDensity = val;
+        } else if (ctrl === 'social-hue') {
+          let hue = '#f0d9a8', rgb = '240, 217, 168';
+          if (val === 'warm-grey') { hue = '#bcb3a8'; rgb = '188, 179, 168'; }
+          if (val === 'dusk') { hue = '#e8a3a3'; rgb = '232, 163, 163'; }
+          document.documentElement.style.setProperty('--k-social', hue);
+          document.querySelectorAll('.pill[data-kind="dms"], .pill[data-kind="group"]').forEach(p => {
+            p.style.setProperty('--kind', hue);
+            p.style.setProperty('--kind-rgb', rgb);
+          });
+        } else if (ctrl === 'vote-indicator') {
+          document.body.dataset.voteIndicator = val;
+        } else if (ctrl === 'boundary-copy' || ctrl === 'hero-size') {
+          rebuildBoundary(parseFloat(scrubber.value));
+        }
+      });
+    });
+  });
+
+  // ---------- Init ----------
+  buildStateGrid();
+  buildRow();
+  setupDayBand();
+  setT(-30);
+</script>
+
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "dependencies": {
         "@khmyznikov/pwa-install": "^0.6.2",
         "@pecking-order/auth": "*",
+        "@pecking-order/cartridges": "*",
         "@pecking-order/game-cartridges": "*",
         "@pecking-order/shared-types": "*",
         "@pecking-order/ui-kit": "*",
@@ -65,6 +66,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@pecking-order/auth": "*",
+        "@pecking-order/cartridges": "*",
         "@pecking-order/game-cartridges": "*",
         "@pecking-order/shared-types": "*",
         "@pushforge/builder": "^2.0.1",

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -175,6 +175,8 @@ export const PushTriggerSchema = z.enum([
   'END_GAME',
   'START_ACTIVITY',
   'END_ACTIVITY',
+  'DILEMMA',
+  'END_DILEMMA',
   // Confession phase
   'CONFESSION_OPEN',
 ]);
@@ -189,6 +191,7 @@ export const DEFAULT_PUSH_CONFIG: Record<PushTrigger, boolean> = {
   DAY_START: true, ACTIVITY: true, VOTING: true, NIGHT_SUMMARY: true, DAILY_GAME: true,
   OPEN_DMS: true, CLOSE_DMS: true, OPEN_GROUP_CHAT: true, CLOSE_GROUP_CHAT: true,
   START_GAME: true, END_GAME: true, START_ACTIVITY: true, END_ACTIVITY: true,
+  DILEMMA: true, END_DILEMMA: true,
   CONFESSION_OPEN: true,
 };
 

--- a/packages/ui-kit/src/tailwind-preset.js
+++ b/packages/ui-kit/src/tailwind-preset.js
@@ -44,6 +44,7 @@ module.exports = {
                     // Core
                     base: 'var(--po-text)',
                     dim: 'var(--po-text-dim)',
+                    faint: 'var(--po-text-faint)',
                     inverted: 'var(--po-text-inverted)',
                     gold: 'var(--po-gold)',
                     pink: 'var(--po-pink)',
@@ -126,6 +127,7 @@ module.exports = {
             boxShadow: {
                 card: 'var(--po-shadow-card)',
                 glow: 'var(--po-shadow-glow)',
+                'glow-pink': 'var(--po-shadow-glow-pink)',
                 btn: 'var(--po-shadow-btn)',
             },
             animation: {

--- a/packages/ui-kit/src/theme.css
+++ b/packages/ui-kit/src/theme.css
@@ -4,8 +4,12 @@
    Import via: @import '@pecking-order/ui-kit/theme.css';
    ============================================================ */
 
-/* --- Fonts --- */
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700;900&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+/* --- Fonts ---
+   Lobby ships Big Shoulders Display (display) + Manrope (body). Both off the
+   impeccable reflex-font list. JetBrains Mono retained for ACTUAL monospace
+   need only (invite codes, timers) — never for "developer aesthetic" texture.
+   See apps/lobby/.impeccable.md for typography rules. */
+@import url('https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@500;700;800;900&family=Manrope:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
 
 /* ============================================================
    THEME: Reality TV  (default)
@@ -25,6 +29,7 @@
   /* Text */
   --po-text: #ffffff;
   --po-text-dim: #d8b4fe;
+  --po-text-faint: #b39ad6; /* ≥4.5:1 on --po-bg-deep — replaces text-skin-dim/40 ad-hoc usage */
   --po-text-inverted: #000000;
 
   /* Accents */
@@ -44,10 +49,10 @@
   --po-border: rgba(255, 255, 255, 0.1);
   --po-border-active: #fbbf24;
 
-  /* Typography */
-  --po-font-display: 'Poppins', sans-serif;
-  --po-font-body: 'Inter', sans-serif;
-  --po-font-mono: 'JetBrains Mono', monospace;
+  /* Typography — see apps/lobby/.impeccable.md */
+  --po-font-display: 'Big Shoulders Display', system-ui, sans-serif;
+  --po-font-body: 'Manrope', system-ui, sans-serif;
+  --po-font-mono: 'JetBrains Mono', ui-monospace, monospace;
 
   /* Radii */
   --po-radius-card: 16px;
@@ -55,9 +60,16 @@
   --po-radius-pill: 30px;
   --po-radius-badge: 12px;
 
-  /* Shadows */
-  --po-shadow-card: 0 8px 32px rgba(0, 0, 0, 0.3);
+  /* Shadows — tinted to brand palette instead of the generic
+     "0 8px 32px rgba(0,0,0,0.3)" AI-card shadow. Top inner highlight +
+     under-bleed in the brand-deep hue gives surfaces a felt-poster
+     quality instead of a floating-rectangle one. */
+  --po-shadow-card:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 12px 32px -12px rgba(44, 0, 62, 0.85),
+    0 4px 12px -4px rgba(190, 24, 93, 0.18);
   --po-shadow-glow: 0 0 15px var(--po-gold-dim);
+  --po-shadow-glow-pink: 0 0 18px rgba(236, 72, 153, 0.35);
   --po-shadow-btn: 0 4px 0 var(--po-pink-depth);
 
   /* Gradient */


### PR DESCRIPTION
## Summary

A multi-pass polish of the **lobby** app (and adjacent share entry points in client + nudge-worker) plus a couple of latent push-notification fixes that surfaced along the way.

The lobby gets its own `apps/lobby/.impeccable.md` design brief — distinct from the Pulse shell — and the brand mantra **`Vote. Ally. Betray. Survive.`** now runs through every share surface (web, OG cards, emails, in-game).

### Touched

- `/playtest`, `/playtest/share/[code]`, `/login`, `/j/[code]`, `/join/[code]` (4-step wizard), `/game/[id]/waiting`
- All Resend email templates (lobby `email-templates.ts` + nudge-worker `index.ts`)
- Web Share + clipboard + SMS / WhatsApp share entry points
- OG metadata per-route (was generic root-only before)
- `packages/ui-kit` design tokens (fonts, contrast-safe text, tinted shadows)
- `apps/lobby/middleware.ts` — public paths un-gated
- `apps/client/src/shells/pulse/components/caststrip/ShareChip.tsx` — share text tightened
- `apps/game-server/src/push-triggers.ts` + tests + shared-types — push-copy gaps closed

## Highlights

**Design system (ui-kit)**
- Fonts: dropped Inter (banned reflex) + Poppins → **Big Shoulders Display + Manrope**
- New `text-skin-faint` (~7:1 on deep purple) replaces ad-hoc `text-skin-dim/40` (failed AA)
- `--po-shadow-card` now layered + tinted (no more "0 8px 32px rgba(0,0,0,0.3)" generic AI shadow)

**Lobby UX**
- `/playtest`: removed `TeaserBadge` icon-cards row; replaced with typographic verb-stack statement
- `/login`: flattened nested glassmorphism stack to a single opaque card; submit-and-validate replaces disabled-button pattern
- `/j/[code]`: empty-state verb-stack; per-route OG metadata pulls host persona name (`${HostName} added you to Pecking Order`)
- `/join/[code]` wizard: 44×44 hit areas on step pips + carousel arrows; section labels promoted to `<h2>`; Step 4 confirm rebuilt as a tabloid-cover reveal with skewed `Locked In` press-stamp; Q&A skip-default randomized (was all-zero — every skipper got identical dossiers)
- `/game/[id]/waiting`: full share-button row (Native Share / SMS / WhatsApp / Copy) with mantra-led per-channel text; empty slots `?`+`TBD` → `Open seat` / `Waiting on someone`; `glow-breathe` reserved for the most-recent join

**Contrast pass on the wizard**
- Page-bg overlay over blurred persona photo: `bg-skin-deep/60` → `/72`. Single biggest readability win.
- Helper microcopy across all steps bumped from `text-skin-faint` → `text-skin-dim` for AA on photo-tinted backgrounds.

**Email + unfurls**
- New `verbStack` helper used in `buildInviteEmail`, `buildPlaytestConfirmationEmail`, and the `NEVER_CLICKED` nudge
- Per-route OG metadata for `/j/[code]` (host-aware) and `/playtest/share/[code]` (referral-specific)
- Root + playtest layout descriptions aligned to mantra

**Hardening across share entry points**
- Robust clipboard (`writeClipboard` helper: modern API → `execCommand` fallback for non-secure / in-app webview contexts)
- Popup-blocked recovery (`window.open` null → in-tab fallback)
- DB error fallback in `/j/[code]` metadata (host-name lookup wrapped in try/catch)
- Cross-platform `sms:?&body=` URL form (works on iOS + Android + macOS Messages.app)

**Push-trigger fixes (separate from lobby polish)**
- ACTIVITY/END_ACTIVITY pushes were reading `dayManifest.promptType` but the field is `activityType` — always returned `UNKNOWN`. Now correctly names prompts (Hot Take, Would You Rather, etc.) using `CARTRIDGE_INFO`.
- DAILY_GAME/END_GAME local map missed 9 newer games (FLAPPY, RECALL, BLINK, etc.) — those pushed as the literal word "Game". Now pulls from `CARTRIDGE_INFO`.
- DILEMMA / END_DILEMMA `PUSH.PHASE` triggers fire from L3 but weren't in the enum or `phasePushPayload` switch — pushed nothing at all. Both added.

**Lobby middleware fix**
- `/playtest`, `/playtest/share/:code`, `/share/:code` were in the auth-gate list. Vanity-domain rewrite still works; gate now bypassed for these public recruitment surfaces.

## Test plan

- [x] `npm run test` in game-server: 461/461 pass
- [x] `tsc --noEmit` clean across game-server, lobby, client, nudge-worker
- [x] `next build` clean — all 11 lobby routes compile
- [x] `npx turbo build --filter='./packages/*'` builds clean
- [x] Local D1 migrations applied; seed game `POLISH1` walks the full flow
- [ ] Verify `/j/POLISH1` host-aware unfurl in iMessage (requires public tunnel — tested via curl + view-source only locally)
- [ ] Manual pass through invite → wizard → waiting on staging
- [ ] Spot-check email rendering in Apple Mail / Gmail / Outlook
- [ ] Verify Web Share API behavior on iOS Safari + Android Chrome

## Known follow-ups (not in this PR)

- `og-playtest.png` returns 404 on production `lobby.peckingorder.ca` — predates this PR but worth investigating before relying on rich unfurls.
- `next/image` migration for persona portraits — defer; large mechanical change.
- Dead `cyberpunk` theme block in `theme.css` left in place; remove in a separate cleanup pass if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)